### PR TITLE
Only allow once instance of the integration to be installed

### DIFF
--- a/custom_components/alarmo/config_flow.py
+++ b/custom_components/alarmo/config_flow.py
@@ -17,6 +17,11 @@ class AlarmoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
+
+        # Only a single instance of the integration
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
         id = secrets.token_hex(6)
 
         await self.async_set_unique_id(id)


### PR DESCRIPTION
Without this change, the user can attempt to install two instances of alarm, which will put the system into a bad state (which I did by a mis click).

NOTE: I haven't tested this, but I believe this is the standard way to make only 1 instance installable, see https://github.com/home-assistant/core/search?q=_async_current_entries