### PR TITLE
Restore `delay` state attribute

### DIFF
--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -257,6 +257,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             "arm_mode": self.arm_mode,
             "open_sensors": self.open_sensors,
             "bypassed_sensors": self.bypassed_sensors,
+            "delay": self.delay,
         }
 
     def _validate_code(self, code, state):


### PR DESCRIPTION
Restore `delay` state attribute needed for [Ring Keypad blueprint](https://community.home-assistant.io/t/synchronize-ring-alarm-keypad-v2-with-alarmo/349461).