### PR TITLE
Treat CO sensors as Environmental

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ The following table defines the sensor types and the predefined configuration:
 | Window        | `window`                                              | `Armed Away`<br>`Armed Home`<br>`Armed Night`<br>`Armed Vacation`  | -                                         |
 | Motion        | `motion`<br>`moving`<br>`occupancy`<br>`presence`     | `Armed Away`<br>`Armed Vacation`                                   | `Use exit delay`<br>`Use entry delay`     |
 | Tamper        | `sound`<br>`opening`<br> `vibration`                  | `Armed Away`<br>`Armed Home`<br>`Armed Night`<br>`Armed Vacation`  | -                                         |
-| Environmental | `gas`<br> `heat`<br>`moisture`<br>`smoke`<br>`safety` | N/A                                                                | `Always on`                               |
+| Environmental | `carbon_monoxide`<br>`gas`<br> `heat`<br>`moisture`<br>`smoke`<br>`safety` | N/A                                                                | `Always on`                               |
 
 
 #### Configuration options

--- a/custom_components/alarmo/frontend/src/data/sensors.ts
+++ b/custom_components/alarmo/frontend/src/data/sensors.ts
@@ -13,6 +13,7 @@ export const isValidSensor = (entity: HassEntity, showAllDeviceClasses: boolean)
     if (!type) return false;
     if (
       [
+        'carbon_monoxide',
         'door',
         'garage_door',
         'gas',
@@ -45,6 +46,7 @@ export const sensorClassToType = (stateObj: HassEntity): ESensorTypes | undefine
       return ESensorTypes.Door;
     case 'window':
       return ESensorTypes.Window;
+    case 'carbon_monoxide':
     case 'gas':
     case 'heat':
     case 'moisture':


### PR DESCRIPTION
Hi there! This PR treats binary sensors of type `carbon_monoxide` as Environmental sensors.

I'm afraid this PR is somewhat incomplete as I couldn't get the build/compile steps to run locally without creating a huge diff, so I didn't update `dist/alarm-panel.js`. Apologies if I missed any docs on how you'd like that done, but figured the PR would be easier to read without a bunch of unrelated changes!

Thanks so much for Alarmo—I'm just getting started with it but it seems really useful!