### PR TITLE
Allow to set "bypass_open_sensors" and "skip_delay" when arm the alarm using a mqtt command

### DIFF
--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -432,30 +432,30 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             context_id=context_id
         )
 
-    async def async_alarm_arm_away(self, code=None, skip_code=False):
+    async def async_alarm_arm_away(self, code=None, skip_code=False, bypass_open_sensors=False):
         """Send arm away command."""
         _LOGGER.debug("alarm_arm_away")
-        await self.async_handle_arm_request(STATE_ALARM_ARMED_AWAY, code=code, skip_code=skip_code)
+        await self.async_handle_arm_request(STATE_ALARM_ARMED_AWAY, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors)
 
-    async def async_alarm_arm_home(self, code=None, skip_code=False):
+    async def async_alarm_arm_home(self, code=None, skip_code=False, bypass_open_sensors=False):
         """Send arm home command."""
         _LOGGER.debug("alarm_arm_home")
-        await self.async_handle_arm_request(STATE_ALARM_ARMED_HOME, code=code, skip_code=skip_code)
+        await self.async_handle_arm_request(STATE_ALARM_ARMED_HOME, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors)
 
-    async def async_alarm_arm_night(self, code=None, skip_code=False):
+    async def async_alarm_arm_night(self, code=None, skip_code=False, bypass_open_sensors=False):
         """Send arm night command."""
         _LOGGER.debug("alarm_arm_night")
-        await self.async_handle_arm_request(STATE_ALARM_ARMED_NIGHT, code=code, skip_code=skip_code)
+        await self.async_handle_arm_request(STATE_ALARM_ARMED_NIGHT, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors)
 
-    async def async_alarm_arm_custom_bypass(self, code=None, skip_code=False):
+    async def async_alarm_arm_custom_bypass(self, code=None, skip_code=False, bypass_open_sensors=False):
         """Send arm custom_bypass command."""
         _LOGGER.debug("alarm_arm_custom_bypass")
-        await self.async_handle_arm_request(STATE_ALARM_ARMED_CUSTOM_BYPASS, code=code, skip_code=skip_code)
+        await self.async_handle_arm_request(STATE_ALARM_ARMED_CUSTOM_BYPASS, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors)
 
-    async def async_alarm_arm_vacation(self, code=None, skip_code=False):
+    async def async_alarm_arm_vacation(self, code=None, skip_code=False, bypass_open_sensors=False):
         """Send arm vacation command."""
         _LOGGER.debug("alarm_arm_vacation")
-        await self.async_handle_arm_request(STATE_ALARM_ARMED_VACATION, code=code, skip_code=skip_code)
+        await self.async_handle_arm_request(STATE_ALARM_ARMED_VACATION, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors)
 
     async def async_alarm_trigger(self, code=None) -> None:
         """Send alarm trigger command."""

--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -432,30 +432,30 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             context_id=context_id
         )
 
-    async def async_alarm_arm_away(self, code=None, skip_code=False, bypass_open_sensors=False):
+    async def async_alarm_arm_away(self, code=None, skip_code=False, bypass_open_sensors=False, skip_delay=False):
         """Send arm away command."""
         _LOGGER.debug("alarm_arm_away")
-        await self.async_handle_arm_request(STATE_ALARM_ARMED_AWAY, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors)
+        await self.async_handle_arm_request(STATE_ALARM_ARMED_AWAY, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors, skip_delay=skip_delay)
 
-    async def async_alarm_arm_home(self, code=None, skip_code=False, bypass_open_sensors=False):
+    async def async_alarm_arm_home(self, code=None, skip_code=False, bypass_open_sensors=False, skip_delay=False):
         """Send arm home command."""
         _LOGGER.debug("alarm_arm_home")
-        await self.async_handle_arm_request(STATE_ALARM_ARMED_HOME, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors)
+        await self.async_handle_arm_request(STATE_ALARM_ARMED_HOME, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors, skip_delay=skip_delay)
 
-    async def async_alarm_arm_night(self, code=None, skip_code=False, bypass_open_sensors=False):
+    async def async_alarm_arm_night(self, code=None, skip_code=False, bypass_open_sensors=False, skip_delay=False):
         """Send arm night command."""
         _LOGGER.debug("alarm_arm_night")
-        await self.async_handle_arm_request(STATE_ALARM_ARMED_NIGHT, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors)
+        await self.async_handle_arm_request(STATE_ALARM_ARMED_NIGHT, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors, skip_delay=skip_delay)
 
-    async def async_alarm_arm_custom_bypass(self, code=None, skip_code=False, bypass_open_sensors=False):
+    async def async_alarm_arm_custom_bypass(self, code=None, skip_code=False, bypass_open_sensors=False, skip_delay=False):
         """Send arm custom_bypass command."""
         _LOGGER.debug("alarm_arm_custom_bypass")
-        await self.async_handle_arm_request(STATE_ALARM_ARMED_CUSTOM_BYPASS, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors)
+        await self.async_handle_arm_request(STATE_ALARM_ARMED_CUSTOM_BYPASS, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors, skip_delay=skip_delay)
 
-    async def async_alarm_arm_vacation(self, code=None, skip_code=False, bypass_open_sensors=False):
+    async def async_alarm_arm_vacation(self, code=None, skip_code=False, bypass_open_sensors=False, skip_delay=False):
         """Send arm vacation command."""
         _LOGGER.debug("alarm_arm_vacation")
-        await self.async_handle_arm_request(STATE_ALARM_ARMED_VACATION, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors)
+        await self.async_handle_arm_request(STATE_ALARM_ARMED_VACATION, code=code, skip_code=skip_code, bypass_open_sensors=bypass_open_sensors, skip_delay=skip_delay)
 
     async def async_alarm_trigger(self, code=None) -> None:
         """Send alarm trigger command."""

--- a/custom_components/alarmo/mqtt.py
+++ b/custom_components/alarmo/mqtt.py
@@ -188,6 +188,7 @@ class MqttHandler:
         command = None
         code = None
         area = None
+        bypass_open_sensors = False
         try:
             payload = json.loads(msg.payload)
             payload = {k.lower(): v for k, v in payload.items()}

--- a/custom_components/alarmo/mqtt.py
+++ b/custom_components/alarmo/mqtt.py
@@ -189,6 +189,8 @@ class MqttHandler:
         code = None
         area = None
         bypass_open_sensors = False
+        skip_delay = False
+
         try:
             payload = json.loads(msg.payload)
             payload = {k.lower(): v for k, v in payload.items()}
@@ -216,6 +218,9 @@ class MqttHandler:
 
             if ("bypass_open_sensors" in payload and payload["bypass_open_sensors"]) or ("force" in payload and payload["force"]):
                 bypass_open_sensors = payload["bypass_open_sensors"]
+
+            if const.ATTR_SKIP_DELAY in payload and payload[const.ATTR_SKIP_DELAY]:
+                skip_delay = payload[const.ATTR_SKIP_DELAY]
 
         except ValueError:
             # no JSON structure found
@@ -262,12 +267,12 @@ class MqttHandler:
         if command == command_payloads[const.COMMAND_DISARM]:
             await entity.async_alarm_disarm(code=code, skip_code=skip_code)
         elif command == command_payloads[const.COMMAND_ARM_AWAY]:
-            await entity.async_alarm_arm_away(code, skip_code, bypass_open_sensors)
+            await entity.async_alarm_arm_away(code, skip_code, bypass_open_sensors, skip_delay)
         elif command == command_payloads[const.COMMAND_ARM_NIGHT]:
-            await entity.async_alarm_arm_night(code, skip_code, bypass_open_sensors)
+            await entity.async_alarm_arm_night(code, skip_code, bypass_open_sensors, skip_delay)
         elif command == command_payloads[const.COMMAND_ARM_HOME]:
-            await entity.async_alarm_arm_home(code, skip_code, bypass_open_sensors)
+            await entity.async_alarm_arm_home(code, skip_code, bypass_open_sensors, skip_delay)
         elif command == command_payloads[const.COMMAND_ARM_CUSTOM_BYPASS]:
-            await entity.async_alarm_arm_custom_bypass(code, skip_code, bypass_open_sensors)
+            await entity.async_alarm_arm_custom_bypass(code, skip_code, bypass_open_sensors, skip_delay)
         elif command == command_payloads[const.COMMAND_ARM_VACATION]:
-            await entity.async_alarm_arm_vacation(code, skip_code, bypass_open_sensors)
+            await entity.async_alarm_arm_vacation(code, skip_code, bypass_open_sensors, skip_delay)

--- a/custom_components/alarmo/mqtt.py
+++ b/custom_components/alarmo/mqtt.py
@@ -213,6 +213,9 @@ class MqttHandler:
             if "area" in payload and payload["area"]:
                 area = payload["area"]
 
+            if ("bypass_open_sensors" in payload and payload["bypass_open_sensors"]) or ("force" in payload and payload["force"]):
+                bypass_open_sensors = payload["bypass_open_sensors"]
+
         except ValueError:
             # no JSON structure found
             command = msg.payload
@@ -258,12 +261,12 @@ class MqttHandler:
         if command == command_payloads[const.COMMAND_DISARM]:
             await entity.async_alarm_disarm(code=code, skip_code=skip_code)
         elif command == command_payloads[const.COMMAND_ARM_AWAY]:
-            await entity.async_alarm_arm_away(code, skip_code)
+            await entity.async_alarm_arm_away(code, skip_code, bypass_open_sensors)
         elif command == command_payloads[const.COMMAND_ARM_NIGHT]:
-            await entity.async_alarm_arm_night(code, skip_code)
+            await entity.async_alarm_arm_night(code, skip_code, bypass_open_sensors)
         elif command == command_payloads[const.COMMAND_ARM_HOME]:
-            await entity.async_alarm_arm_home(code, skip_code)
+            await entity.async_alarm_arm_home(code, skip_code, bypass_open_sensors)
         elif command == command_payloads[const.COMMAND_ARM_CUSTOM_BYPASS]:
-            await entity.async_alarm_arm_custom_bypass(code, skip_code)
+            await entity.async_alarm_arm_custom_bypass(code, skip_code, bypass_open_sensors)
         elif command == command_payloads[const.COMMAND_ARM_VACATION]:
-            await entity.async_alarm_arm_vacation(code, skip_code)
+            await entity.async_alarm_arm_vacation(code, skip_code, bypass_open_sensors)


### PR DESCRIPTION
Allow to include "bypass_open_sensors" (or "force") modifier as a MQTT command parameter to allow the alarm to be armed event if open sensors.
Also allow to include "skip_delay" modifier as a MQTT command parameter to allow the alarm to be armed immediately.