### PR TITLE
Register as config panel

### DIFF
--- a/custom_components/alarmo/panel.py
+++ b/custom_components/alarmo/panel.py
@@ -35,10 +35,9 @@ async def async_register_panel(hass):
         webcomponent_name=PANEL_NAME,
         frontend_url_path=DOMAIN,
         module_url=PANEL_URL,
-        sidebar_title=PANEL_TITLE,
-        sidebar_icon=PANEL_ICON,
         require_admin=True,
         config={},
+        config_panel_domain=DOMAIN,
     )
 
 

--- a/custom_components/alarmo/panel.py
+++ b/custom_components/alarmo/panel.py
@@ -35,6 +35,8 @@ async def async_register_panel(hass):
         webcomponent_name=PANEL_NAME,
         frontend_url_path=DOMAIN,
         module_url=PANEL_URL,
+        sidebar_title=PANEL_TITLE,
+        sidebar_icon=PANEL_ICON,
         require_admin=True,
         config={},
         config_panel_domain=DOMAIN,


### PR DESCRIPTION
Register alarmo panel as config panel like ZHA/Matter/... instead of in the sidebar. This capability was introduced mid this year (https://github.com/home-assistant/core/pull/96245) in the HA core.

I don't know if we should keep the entry in the sidebar for reasons of "backwards compatibility" so as not to confuse users.

https://github.com/nielsfaber/alarmo/assets/3989428/86b73838-6dc4-4b9b-af1c-9313e014bdbb
