### PR TITLE
Avoid use of deprecated `hass.helpers`

### DIFF
--- a/custom_components/alarmo/__init__.py
+++ b/custom_components/alarmo/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     ATTR_NAME,
 )
 from homeassistant.core import HomeAssistant, asyncio
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.dispatcher import (
@@ -346,7 +346,7 @@ class AlarmoCoordinator(DataUpdateCoordinator):
         )
 
     async def async_remove_entity(self, area_id: str):
-        entity_registry = self.hass.helpers.entity_registry.async_get(self.hass)
+        entity_registry = er.async_get(self.hass)
         if area_id == "master":
             entity = self.hass.data[const.DOMAIN]["master"]
             entity_registry.async_remove(entity.entity_id)

--- a/custom_components/alarmo/automations.py
+++ b/custom_components/alarmo/automations.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 
 from homeassistant.components.notify import ATTR_MESSAGE
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.translation import async_get_translations
 
 from homeassistant.components.binary_sensor.device_condition import (
     ENTITY_CONDITIONS,
@@ -245,7 +246,8 @@ class AutomationHandler:
         ):
             translations = self._sensorTranslationCache
         else:
-            translations = await self.hass.helpers.translation.async_get_translations(
+            translations = await async_get_translations(
+                self.hass,
                 language,
                 "device_automation",
                 ["binary_sensor"]
@@ -294,7 +296,8 @@ class AutomationHandler:
         ):
             translations = self._alarmTranslationCache
         else:
-            translations = await self.hass.helpers.translation.async_get_translations(
+            translations = await async_get_translations(
+                self.hass,
                 language,
                 "entity_component",
                 ["alarm_control_panel"]


### PR DESCRIPTION
With the HA release 2024.5 we start deprecating the use of `hass.helpers` (https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers/). This will be a breaking change with version 2024.11.