### PR TITLE
Make code a positional argument for async_alarm_disarm

### DIFF
--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -307,16 +307,18 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             self._changed_by = res[ATTR_NAME]
             return (True, res)
 
-    async def async_service_disarm_handler(self, code, context_id=None):
+    @callback
+    def async_service_disarm_handler(self, code, context_id=None):
         """handle external disarm request from alarmo.disarm service"""
         _LOGGER.debug("Service alarmo.disarm was called")
 
-        await self.async_alarm_disarm(
+        self.async_alarm_disarm(
             code=code,
             context_id=context_id
         )
 
-    async def async_alarm_disarm(self, code, **kwargs):
+    @callback
+    def alarm_disarm(self, code, **kwargs):
         """Send disarm command."""
         _LOGGER.debug("alarm_disarm")
         skip_code = kwargs.get("skip_code", False)

--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -307,21 +307,18 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             self._changed_by = res[ATTR_NAME]
             return (True, res)
 
-    @callback
-    def async_service_disarm_handler(self, code, context_id=None):
+    async def async_service_disarm_handler(self, code, context_id=None):
         """handle external disarm request from alarmo.disarm service"""
         _LOGGER.debug("Service alarmo.disarm was called")
 
-        self.async_alarm_disarm(
+        await self.async_alarm_disarm(
             code=code,
             context_id=context_id
         )
 
-    @callback
-    def async_alarm_disarm(self, **kwargs):
+    async def async_alarm_disarm(self, code, **kwargs):
         """Send disarm command."""
         _LOGGER.debug("alarm_disarm")
-        code = kwargs.get("code", None)
         skip_code = kwargs.get("skip_code", False)
         context_id = kwargs.get("context_id", None)
 


### PR DESCRIPTION
With HA 2024.6.0 `code` needs to be a positional argument to `async_alarm_disarm`.

Fixes https://github.com/nielsfaber/alarmo/issues/952