### PR TITLE
add sensor config services

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,64 @@ Structure of the event data:
 }
 ```
 
+---
+
+Alarmo supports two admin services for advanced sensor configuration:
+
+**Disable an Alarmo sensor**
+
+Example YAML:
+```yaml
+service: alarmo.set_sensor_configuration
+data:
+  entity_id: binary_sensor.virtual_window_sensor_window
+  enabled: false
+```
+
+**`alarmo.set_sensor_configuration`**  
+Update Alarmo-specific configuration for one or more sensors. Supports updating type, enabled state, modes, and advanced flags (e.g., auto_bypass).
+
+Example YAML:
+```yaml
+service: alarmo.set_sensor_configuration
+data:
+  entity_id:
+    - binary_sensor.virtual_motion_sensor_motion
+    - binary_sensor.virtual_window_sensor_window
+  type: door
+  modes:
+    - armed_away
+    - armed_home
+  use_exit_delay: false
+  always_on: false
+  auto_bypass: true
+  auto_bypass_modes:
+    - armed_away
+```
+
+**`alarmo.get_sensor_configuration`**  
+Retrieve the Alarmo configuration for a specific sensor.
+
+Example YAML:
+```yaml
+service: alarmo.get_sensor_configuration
+data:
+  entity_id: binary_sensor.virtual_window_sensor_window
+```
+
+To read the sensor configuration after calling the get_sensor_configuration action listen for the event `alarmo_sensor_get_config_event` in Home Assistant. You can do this in Developer Tools > Events, or in an automation:
+
+```yaml
+trigger:
+  - platform: event
+    event_type: alarmo_sensor_get_config_event
+action:
+  - service: logbook.log
+    data:
+      name: "Alarmo sensor config"
+      message: "{{ trigger.event.data }}"
+```
+
 #### Automatic arming
 If you want to control the state of Alarmo through an external device (e.g. a keyfob, button panel, or phone with geofencing), you can do so by means of a HA automation.
 

--- a/custom_components/alarmo/const.py
+++ b/custom_components/alarmo/const.py
@@ -222,3 +222,21 @@ SERVICE_TOGGLE_USER_SCHEMA = vol.Schema(
         vol.Required(ATTR_NAME, default=""): cv.string,
     }
 )
+
+SERVICE_SET_SENSOR_CONFIGURATION = "set_sensor_configuration"
+SERVICE_GET_SENSOR_CONFIGURATION = "get_sensor_configuration"
+EVENT_ALARMO_SENSOR_GET_CONFIG_EVENT = "alarmo_sensor_get_config_event"
+
+FRIENDLY_TO_INTERNAL_MODE = {
+    "away": "armed_away",
+    "home": "armed_home",
+    "night": "armed_night",
+    "custom": "armed_custom_bypass",
+    "vacation": "armed_vacation",
+    # Allow internal names as well
+    "armed_away": "armed_away",
+    "armed_home": "armed_home",
+    "armed_night": "armed_night",
+    "armed_custom_bypass": "armed_custom_bypass",
+    "armed_vacation": "armed_vacation",
+}

--- a/custom_components/alarmo/sensor_service.py
+++ b/custom_components/alarmo/sensor_service.py
@@ -1,0 +1,392 @@
+"""Sensor service logic for Alarmo (service handlers for setting/getting sensor configuration."""
+
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from . import const
+from .const import FRIENDLY_TO_INTERNAL_MODE
+from .sensors import (
+    ATTR_ALLOW_OPEN,
+    ATTR_ALWAYS_ON,
+    ATTR_ARM_ON_CLOSE,
+    ATTR_AUTO_BYPASS,
+    ATTR_AUTO_BYPASS_MODES,
+    ATTR_TRIGGER_UNAVAILABLE,
+    ATTR_USE_ENTRY_DELAY,
+    ATTR_USE_EXIT_DELAY,
+    SENSOR_TYPES,
+)
+
+if TYPE_CHECKING:
+    from .__init__ import AlarmoCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+def build_sensor_config_schema(all_active_area_modes: set[str]) -> vol.Schema:
+    """Build a validation schema for sensor configuration based on active area modes."""
+
+    def _build_modes_validator(all_active_area_modes: set[str]):
+        def validate_modes(modes: list[str]) -> list[str]:
+            # Empty modes lists are allowed - we'll validate elsewhere if auto_bypass requires them
+            if not modes:
+                return modes
+            # When modes are provided, they must all be valid
+            invalid_modes = set(modes) - all_active_area_modes
+            if invalid_modes:
+                raise vol.Invalid(f"Invalid modes: {list(invalid_modes)}. Valid: {sorted(all_active_area_modes)}")
+            return modes
+        return validate_modes
+
+    return vol.Schema({
+        vol.Optional(const.ATTR_TYPE): vol.In(SENSOR_TYPES),
+        vol.Optional(const.ATTR_MODES): vol.All(
+            vol.Any([str], list),
+            _build_modes_validator(all_active_area_modes)
+        ),
+        vol.Optional(const.ATTR_ENABLED): cv.boolean,
+        vol.Optional(ATTR_USE_EXIT_DELAY): cv.boolean,
+        vol.Optional(ATTR_USE_ENTRY_DELAY): cv.boolean,
+        vol.Optional(ATTR_ALWAYS_ON): cv.boolean,
+        vol.Optional(ATTR_ARM_ON_CLOSE): cv.boolean,
+        vol.Optional(ATTR_ALLOW_OPEN): cv.boolean,
+        vol.Optional(ATTR_TRIGGER_UNAVAILABLE): cv.boolean,
+        vol.Optional(ATTR_AUTO_BYPASS): cv.boolean,
+        vol.Optional(ATTR_AUTO_BYPASS_MODES): vol.Any([str], list),
+    }, extra=vol.PREVENT_EXTRA)
+
+def auto_bypass_validator(
+    config_dict: dict[str, Any],
+    service_call_keys: set[str]
+) -> dict[str, Any]:
+    """Validate auto_bypass/auto_bypass_modes consistency with the alarm modes."""
+
+    validated_config = config_dict.copy()
+    ab_in_call = ATTR_AUTO_BYPASS in service_call_keys
+    abm_in_call = ATTR_AUTO_BYPASS_MODES in service_call_keys
+
+    prospective_auto_bypass = validated_config.get(ATTR_AUTO_BYPASS, False)
+    prospective_ab_modes = validated_config.get(ATTR_AUTO_BYPASS_MODES, [])
+    prospective_main_modes = validated_config.get(const.ATTR_MODES, [])
+
+    # If enabling auto_bypass, require auto_bypass_modes to be present
+    if ab_in_call and prospective_auto_bypass is True and not abm_in_call:
+        raise vol.Invalid(
+            f"If '{ATTR_AUTO_BYPASS}' is True, '{ATTR_AUTO_BYPASS_MODES}' must also be provided."
+        )
+    # If auto_bypass_modes is provided and non-empty, require auto_bypass to be True
+    if (
+        abm_in_call
+        and prospective_ab_modes
+        and not (ab_in_call and prospective_auto_bypass is True)
+    ):
+        raise vol.Invalid(
+            f"If '{ATTR_AUTO_BYPASS_MODES}' is provided and non-empty, "
+            f"'{ATTR_AUTO_BYPASS}' must also be set to True."
+        )
+
+    if ab_in_call and prospective_auto_bypass is True:
+        if not prospective_ab_modes:
+            raise vol.Invalid(
+                f"If '{ATTR_AUTO_BYPASS}' is True, "
+                f"'{ATTR_AUTO_BYPASS_MODES}' must be a non-empty list."
+            )
+
+    # Only check for modes and validate auto_bypass_modes against modes if auto_bypass is True
+    if prospective_auto_bypass is True:
+        if not prospective_ab_modes:
+            raise vol.Invalid(
+                f"When '{ATTR_AUTO_BYPASS}' is True, "
+                f"'{ATTR_AUTO_BYPASS_MODES}' must be a non-empty list."
+            )
+
+        # If auto_bypass is true, we need to have modes
+        if not prospective_main_modes:
+            raise vol.Invalid(
+                f"When '{ATTR_AUTO_BYPASS}' is True, the sensor must have at least one mode configured"
+            )
+
+        # Only check that auto_bypass_modes is a subset of main modes if auto_bypass is true and we have modes
+        invalid_subset = set(prospective_ab_modes) - set(prospective_main_modes)
+        if invalid_subset:
+            raise vol.Invalid(
+                f"'{ATTR_AUTO_BYPASS_MODES}' ({prospective_ab_modes}) contains modes not present "
+                f"in the sensor's operational '{const.ATTR_MODES}' ({prospective_main_modes}): "
+                f"{list(invalid_subset)}."
+            )
+
+    if prospective_auto_bypass is False:
+        if prospective_ab_modes:
+            if ab_in_call and abm_in_call and prospective_ab_modes:
+                raise vol.Invalid(
+                    f"If '{ATTR_AUTO_BYPASS}' is explicitly set to False, "
+                    f"'{ATTR_AUTO_BYPASS_MODES}' must be an empty list if provided. "
+                    f"Got: {prospective_ab_modes}."
+                )
+            validated_config[ATTR_AUTO_BYPASS_MODES] = []
+            _LOGGER.debug(
+                "Auto-bypass is False, clearing auto_bypass_modes from %s to []",
+                prospective_ab_modes
+            )
+    return validated_config
+
+def normalize_modes(modes: Any) -> list[str]:
+    """Normalize mode names from user-friendly to internal representation.
+
+    Handles None, str, and list inputs
+    """
+    if modes is None:
+        return []
+    # Handle single string case
+    if isinstance(modes, str):
+        return [FRIENDLY_TO_INTERNAL_MODE.get(modes, modes)]
+    # Handle list case
+    if isinstance(modes, list):
+        return [
+            FRIENDLY_TO_INTERNAL_MODE.get(item, item) 
+            for item in modes   # type: ignore[var-annotated]
+            if isinstance(item, str)
+        ]
+
+    # Handle unexpected types
+    _LOGGER.warning("Normalize_modes received unexpected type: %s", modes.__class__.__name__)
+    return []
+
+def internal_to_friendly_modes(modes: Any) -> list[str]:
+    """Convert internal mode names to user-friendly names.
+
+    Handles None, str, and list inputs
+    """
+
+    # Handle None case
+    if modes is None:
+        return []
+
+    # Invert the mapping for reverse lookup
+    internal_to_friendly = {
+        v: k
+        for k, v in FRIENDLY_TO_INTERNAL_MODE.items()
+        if not v.startswith('armed_') or k == v
+    }
+
+    # Handle single string case
+    if isinstance(modes, str):
+        return [internal_to_friendly.get(modes, modes)]
+
+    # Handle list case
+    if isinstance(modes, list):
+        return [internal_to_friendly.get(item, item) for item in modes if isinstance(item, str)]  # type: ignore[var-annotated]
+
+    # Handle unexpected types
+    _LOGGER.warning("Internal_to_friendly_modes received unexpected type: %s", modes.__class__.__name__)
+    return []
+
+async def async_service_set_sensor_configuration(hass: HomeAssistant,
+                                                 call: ServiceCall,
+                                                 coordinator: "AlarmoCoordinator"
+) -> None:
+    """Update the Alarmo-specific configuration for one or more sensor entities."""
+
+    _LOGGER.debug("Service call.data received: %s", call.data)
+
+    # Retrieve and validate entity_ids from the service call.
+    entity_ids: list[str] = []
+    entity_ids_raw = call.data.get(const.ATTR_ENTITY_ID)
+    if isinstance(entity_ids_raw, list):
+        # After schema validation by HA core with cv.entity_ids, this list should contain strings.
+        for eid in cast(list[str], entity_ids_raw):
+            if eid: # Ensure non-empty string, though cv.entity_ids should also handle this
+                entity_ids.append(eid)
+    elif isinstance(entity_ids_raw, str) and entity_ids_raw:
+        entity_ids = [entity_ids_raw]
+    else:
+        entity_ids = []
+
+    if not entity_ids:
+        _LOGGER.error("Service set_sensor_configuration called without valid entity_id")
+        return
+
+    # Gather all active arm modes from all areas for validation context.
+    all_active_area_modes: set[str] = set()
+    areas = cast(
+        dict[str, dict[str, Any]],
+        coordinator.store.async_get_areas(),  # type: ignore[no-untyped-call]
+    )
+    for area_data in areas.values():
+        for mode_name, mode_config in area_data.get("modes", {}).items():
+            mode_config_dict: dict[str, Any] = mode_config
+            if mode_config_dict.get("enabled"):
+                all_active_area_modes.add(mode_name)
+
+    if not all_active_area_modes:
+        _LOGGER.warning(
+            "No arm modes are enabled in any area. Mode validation for sensors might be restrictive"
+        )
+
+    # Prepare service parameters (excluding entity_id).
+    raw_service_params_from_call = {k: v for k, v in call.data.items() if k != const.ATTR_ENTITY_ID}
+    service_had_modes_key = const.ATTR_MODES in call.data # Check if user explicitly sent ATTR_MODES
+
+    # Normalize modes in raw_service_params_from_call if present.
+    if const.ATTR_MODES in raw_service_params_from_call:
+        raw_service_params_from_call[const.ATTR_MODES] = normalize_modes(raw_service_params_from_call[const.ATTR_MODES])
+
+    # Normalize auto_bypass_modes in raw_service_params_from_call if present.
+    if ATTR_AUTO_BYPASS_MODES in raw_service_params_from_call:
+        bypass_modes_value = raw_service_params_from_call[ATTR_AUTO_BYPASS_MODES]
+        if bypass_modes_value is not None: # Explicitly null is treated as empty list
+            raw_service_params_from_call[ATTR_AUTO_BYPASS_MODES] = normalize_modes(bypass_modes_value)
+        else:
+            raw_service_params_from_call[ATTR_AUTO_BYPASS_MODES] = []
+
+    # Process each entity
+    for entity_id in entity_ids:
+        try:
+            # If the user explicitly tried to set modes to None or an empty list,
+            # which results in raw_service_params_from_call[const.ATTR_MODES] being [],
+            # this is an invalid operation as sensors must have modes.
+            if service_had_modes_key and not raw_service_params_from_call.get(const.ATTR_MODES):
+                params = {k:v for k,v in call.data.items() if k != const.ATTR_ENTITY_ID}
+                _LOGGER.error(
+                    "Sensor %s: Invalid %s: must have modes. Params: %s",
+                    entity_id, const.ATTR_MODES, params
+                )
+                continue # Skip to the next entity_id
+
+            # At this point, raw_service_params_from_call contains only what the user provided (normalized).
+            # Validate these user-provided parameters first. This will catch unknown keys.
+            settable_fields_schema = build_sensor_config_schema(all_active_area_modes)
+            validated_service_params: dict[str, Any] = settable_fields_schema(raw_service_params_from_call)
+
+            existing_sensor_config = cast(
+                dict[str, Any],
+                coordinator.store.async_get_sensor(entity_id),  # type: ignore[no-untyped-call]
+            )
+            if not existing_sensor_config:
+                _LOGGER.error(
+                    "Sensor %s not found in Alarmo configuration. Cannot update properties",
+                    entity_id,
+                )
+                continue
+
+            # Start with a copy of the existing config, then update with validated service params.
+            # Ensures non-settable fields like 'area' are preserved from existing_sensor_config.
+            prospective_full_config = existing_sensor_config.copy()
+            prospective_full_config.update(validated_service_params)
+
+            # Keys that were actually in the service call (used by auto_bypass_validator)
+            service_call_param_keys = set(raw_service_params_from_call.keys())
+
+            # Perform cross-field validation (e.g., for auto_bypass) if relevant keys 
+            # were in the service call.
+            final_config_to_commit = prospective_full_config
+            if (ATTR_AUTO_BYPASS in service_call_param_keys or 
+                    ATTR_AUTO_BYPASS_MODES in service_call_param_keys):
+                final_config_to_commit = auto_bypass_validator(
+                    prospective_full_config, service_call_param_keys
+                )
+
+            # Filter to only include keys defined in the schema OR 'enabled', before saving.
+            # This ensures we don't accidentally try to save 'area' or other internal fields
+            # that might have been part of existing_sensor_config.
+            config_to_save_to_store = {
+                k: v
+                for k, v in final_config_to_commit.items()
+                if k in settable_fields_schema.schema or k == const.ATTR_ENABLED 
+            }
+
+            coordinator.store.async_update_sensor(entity_id,  # type: ignore[no-untyped-call]
+                                                  config_to_save_to_store)
+
+            _LOGGER.info(
+                "Sensor %s configuration updated. Service params: %s, Applied config: %s",
+                entity_id,
+                {k:v for k,v in call.data.items() if k != const.ATTR_ENTITY_ID},
+                config_to_save_to_store # Log what was actually saved
+            )
+            async_dispatcher_send(hass, "alarmo_sensors_updated")
+
+        except vol.Invalid as err:
+            _LOGGER.error(
+                "Sensor %s: Configuration update failed: %s. Service params: %s",
+                entity_id, err, {k:v for k,v in call.data.items() if k != const.ATTR_ENTITY_ID}
+            )
+            continue # to the next entity_id
+
+async def async_service_get_sensor_configuration(hass: HomeAssistant,
+                                                 call: ServiceCall,
+                                                 coordinator: "AlarmoCoordinator"
+) -> None:
+    """Handle the get_sensor_configuration service call."""
+    _LOGGER.debug("async_service_get_sensor_configuration called with data: %s", call.data)
+    entity_id = call.data.get(const.ATTR_ENTITY_ID)
+    if not entity_id:
+        _LOGGER.error("Service get_sensor_configuration called without entity_id")
+        hass.bus.async_fire(
+            const.EVENT_ALARMO_SENSOR_GET_CONFIG_EVENT,
+            cast(
+                dict[str, Any],
+                {
+                    "entity_id": None,
+                    "configuration": None,
+                    "error": "entity_id_not_provided",
+                },
+            ),
+        )
+        return
+
+    sensor_config = cast(
+        dict[str, Any],
+        coordinator.store.async_get_sensor(entity_id),  # type: ignore[no-untyped-call]
+    )
+
+    if sensor_config:
+        # Convert internal mode names to friendly names for output
+        if const.ATTR_MODES in sensor_config:
+            sensor_config[const.ATTR_MODES] = internal_to_friendly_modes(
+                sensor_config[const.ATTR_MODES]
+            )
+        if ATTR_AUTO_BYPASS_MODES in sensor_config:
+            sensor_config[ATTR_AUTO_BYPASS_MODES] = internal_to_friendly_modes(
+                sensor_config[ATTR_AUTO_BYPASS_MODES]
+            )
+        _LOGGER.debug(
+            "Service get_sensor_configuration: Found config for %s: %s",
+            entity_id, sensor_config
+        )
+        hass.bus.async_fire(
+            const.EVENT_ALARMO_SENSOR_GET_CONFIG_EVENT,
+            cast(
+                dict[str, Any],
+                {
+                    "entity_id": entity_id,
+                    "configuration": dict(sensor_config),
+                    "error": None,
+                },
+            ),
+        )
+    else:
+        _LOGGER.warning(
+            "Service get_sensor_configuration: No Alarmo configuration found for sensor %s",
+            entity_id,
+        )
+        hass.bus.async_fire(
+            const.EVENT_ALARMO_SENSOR_GET_CONFIG_EVENT,
+            cast(
+                dict[str, Any],
+                {
+                    "entity_id": entity_id,
+                    "configuration": None,
+                    "error": "not_configured_in_alarmo",
+                },
+            ),
+        )
+
+SERVICE_SET_SENSOR_CONFIGURATION_SCHEMA: vol.Schema = vol.Schema({
+    vol.Required(const.ATTR_ENTITY_ID): cv.entity_ids,
+}, extra=vol.PREVENT_EXTRA)

--- a/custom_components/alarmo/services.yaml
+++ b/custom_components/alarmo/services.yaml
@@ -1,4 +1,3 @@
-
 arm:
   fields:
     entity_id:
@@ -66,3 +65,129 @@ disable_user:
       required: true
       selector:
         text:
+
+set_sensor_configuration:
+  description: "Sets various configuration properties for one or more Alarmo sensors. You can target a single sensor or a list of sensors. The same configuration will be applied to all specified sensors."
+  fields:
+    entity_id:
+      description: "The Alarmo sensor entity or list of entities to configure. You can specify a single entity_id as a string or multiple as a list."
+      example: '["binary_sensor.door_contact", "binary_sensor.window_contact"]'
+      required: true
+      selector:
+        entity:
+          # We don't have a direct way to filter for Alarmo-managed sensors here,
+          # but the service handler will validate it.
+    type:
+      description: "The type of the sensor (e.g., door, window, motion)."
+      required: false
+      example: "door"
+      selector:
+        select:
+          options:
+            - "door"
+            - "window"
+            - "motion"
+            - "tamper"
+            - "environmental"
+            - "other"
+    modes:
+      description: "List of arm modes in which this sensor is active. Use user-friendly names: home, away, night, custom, vacation."
+      required: false
+      example: '["away", "home"]'
+      selector:
+        select:
+          multiple: true
+          options:
+            - "away"
+            - "night"
+            - "home"
+            - "custom"
+            - "vacation"
+    enabled:
+      description: "Enable or disable this sensor within Alarmo's internal configuration (distinct from the HA entity's enabled state). When disabled, Alarmo will ignore this sensor."
+      required: false
+      example: true
+      selector:
+        boolean:
+    use_exit_delay:
+      description: "Whether the sensor respects the exit delay."
+      required: false
+      selector:
+        boolean:
+      example: true
+    use_entry_delay:
+      description: "Whether the sensor respects the entry delay."
+      required: false
+      selector:
+        boolean:
+      example: true
+    always_on:
+      description: "Whether the sensor is always active, regardless of arm mode."
+      required: false
+      selector:
+        boolean:
+      example: false
+    arm_on_close:
+      description: "Whether the alarm attempts to arm when this sensor closes (if it was an immediate sensor preventing arming)."
+      required: false
+      selector:
+        boolean:
+      example: true
+    allow_open:
+      description: "Whether this sensor is allowed to be open when arming (relevant for immediate sensors)."
+      required: false
+      selector:
+        boolean:
+      example: false
+    trigger_unavailable:
+      description: "Whether the sensor going to an 'unavailable' state should trigger the alarm."
+      required: false
+      selector:
+        boolean:
+      example: true
+    auto_bypass:
+      description: "Automatically bypass this sensor if it's open when arming."
+      required: false
+      selector:
+        boolean:
+      example: true
+    auto_bypass_modes:
+      description: "List of arm modes in which auto-bypass is applicable. Use user-friendly names: home, away, night, custom, vacation. If you provide this field, you must also provide auto_bypass."
+      required: false
+      example: '["away", "home"]'
+      selector:
+        select:
+          multiple: true
+          options:
+            - "away"
+            - "night"
+            - "home"
+            - "custom"
+            - "vacation"
+  example: |
+    entity_id: ["binary_sensor.garden_door_contact"]
+    type: "door"
+    enabled: true
+    modes:
+      - "away"
+      - "home"
+    use_exit_delay: true
+    use_entry_delay: true
+    always_on: false
+    arm_on_close: true
+    allow_open: false
+    trigger_unavailable: true
+    auto_bypass: true
+    auto_bypass_modes:
+      - "away"
+      - "home"
+
+get_sensor_configuration:
+  description: "Retrieves the Alarmo-specific configuration for a given sensor and fires an event with the data. The event type will be 'alarmo_sensor_get_config_event'."
+  fields:
+    entity_id:
+      description: "The Alarmo sensor entity (e.g., binary_sensor.door_contact) to get configuration for."
+      required: true
+      example: "binary_sensor.door_contact"
+      selector:
+        entity: {} # Simple entity selector

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+filterwarnings =
+    ignore::pytest.PytestDeprecationWarning

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+pytest>=7.0.0
+pytest-asyncio>=0.21.0
+pytest-homeassistant-custom-component>=0.12.0

--- a/test/test_sensor_service.py
+++ b/test/test_sensor_service.py
@@ -1,0 +1,363 @@
+"""test_sensor_service.py"""
+
+# To run the tests:
+# pip install -r requirements_test.txt
+# pytest -v tests/test_sensor_service.py
+# pytest tests/    # to run all tests
+
+from typing import Any
+from unittest.mock import MagicMock, patch, ANY  # type: ignore
+import pytest
+from custom_components.alarmo import const
+from custom_components.alarmo.sensor_service import async_service_set_sensor_configuration
+
+@pytest.fixture
+def base_sensor_config() -> dict[str, Any]:
+    """Base sensor configuration"""
+    return {
+        "entity_id": "binary_sensor.virtual_window_sensor_window",
+        "enabled": True,
+        const.ATTR_MODES: ["armed_home"],
+    }
+
+@pytest.fixture
+def mock_coordinator(hass: Any, base_sensor_config: dict[str, Any]) -> Any:
+    """Mock coordinator"""
+    mock_store = MagicMock()
+    # Simulate two sensors in the store
+    mock_store.async_get_sensor.side_effect = lambda eid: dict(base_sensor_config, entity_id=eid)  # type: ignore
+    mock_store.async_update_sensor = MagicMock()
+    mock_store.async_get_areas.return_value = {
+        "area_1": {"modes": {"armed_home": {"enabled": True}, "armed_away": {"enabled": True}}}
+    }
+    coordinator = MagicMock()
+    coordinator.store = mock_store
+    return coordinator
+
+@pytest.mark.asyncio
+async def test_set_sensor_type_only(hass: Any, mock_coordinator: Any):
+    """Test set sensor type only"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_window_sensor_window",
+            "type": "window"
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_called_once()
+        args, _ = mock_coordinator.store.async_update_sensor.call_args
+        assert args[1]["type"] == "window"
+
+@pytest.mark.asyncio
+async def test_set_multiple_sensors_modes_and_flags(hass: Any, mock_coordinator: Any):
+    """Test set multiple sensors modes and flags"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: [
+                "binary_sensor.virtual_motion_sensor_motion",
+                "binary_sensor.virtual_window_sensor_window"
+            ],
+            "type": "door",
+            const.ATTR_MODES: ["armed_away", "armed_home"],
+            "use_exit_delay": False,
+            "always_on": False,
+            "auto_bypass": True,
+            "auto_bypass_modes": ["armed_away"]
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        # Should be called for both sensors
+        assert mock_coordinator.store.async_update_sensor.call_count == 2
+
+@pytest.mark.asyncio
+async def test_fail_auto_bypass_true_no_modes(hass: Any, mock_coordinator: Any):
+    """Test fail auto bypass true no modes"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_window_sensor_window",
+            const.ATTR_MODES: ["armed_home"],
+            "auto_bypass": True,
+            # auto_bypass_modes omitted
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        # Should not update sensor due to validation error
+        mock_coordinator.store.async_update_sensor.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_fail_auto_bypass_modes_not_in_modes(hass: Any, mock_coordinator: Any):
+    """Test fail auto bypass modes not in modes"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_motion_sensor_motion",
+            const.ATTR_MODES: ["armed_home"],
+            "auto_bypass": True,
+            "auto_bypass_modes": ["armed_away"],  # not in main modes
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_fail_auto_bypass_modes_but_flag_false(hass: Any, mock_coordinator: Any):
+    """Test fail auto bypass modes but flag false"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_motion_sensor_motion",
+            const.ATTR_MODES: ["armed_home"],
+            "auto_bypass": False,
+            "auto_bypass_modes": ["armed_home"],
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_fail_auto_bypass_true_modes_missing(hass: Any, mock_coordinator: Any):
+    """Test fail auto bypass true modes missing"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_motion_sensor_motion",
+            const.ATTR_MODES: ["armed_home"],
+            "auto_bypass": True,
+            # auto_bypass_modes is deliberately omitted
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_fail_auto_bypass_modes_but_flag_missing(hass: Any, mock_coordinator: Any):
+    """Test fail auto bypass modes but flag missing"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: [
+                "binary_sensor.virtual_window_sensor_window",
+                "binary_sensor.virtual_motion_sensor_motion"
+            ],
+            "type": "door",
+            const.ATTR_MODES: ["armed_away", "armed_home"],
+            "is_alarmo_sensor_enabled": True,
+            "auto_bypass_modes": ["armed_away", "armed_home"]
+            # auto_bypass flag missing
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_valid_auto_bypass_modes_friendly_name(hass: Any, mock_coordinator: Any):
+    """Test valid auto bypass modes friendly name"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: [
+                "binary_sensor.virtual_window_sensor_window",
+                "binary_sensor.virtual_motion_sensor_motion"
+            ],
+            "type": "door",
+            const.ATTR_MODES: ["armed_away", "armed_home"],
+            "auto_bypass": True,
+            "auto_bypass_modes": ["away"],  # friendly name
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        assert mock_coordinator.store.async_update_sensor.call_count == 2
+
+@pytest.mark.asyncio
+async def test_valid_disable_auto_bypass_clears_modes(hass: Any, mock_coordinator: Any):
+    """Test valid disable auto bypass clears modes"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: [
+                "binary_sensor.virtual_window_sensor_window",
+                "binary_sensor.virtual_motion_sensor_motion"
+            ],
+            "type": "door",
+            const.ATTR_MODES: ["armed_away", "armed_home"],
+            "auto_bypass": False,
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        # Should clear auto_bypass_modes
+        for call_args in mock_coordinator.store.async_update_sensor.call_args_list:
+            updated_config = call_args[0][1]
+            assert updated_config.get("auto_bypass_modes", []) == []
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_only_required(hass: Any, mock_coordinator: Any):
+    """Test: only required parameters (entity_id)"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_window_sensor_window"
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_no_entity_id(hass: Any, mock_coordinator: Any):
+    """Test: service call with no entity_id (should fail)"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            "enabled": True
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_invalid_entity(hass: Any, mock_coordinator: Any):
+    """Test: invalid sensor entity (not in store)"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        mock_coordinator.store.async_get_sensor.side_effect = lambda eid: None  # type: ignore
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.nonexistent"
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_multiple_one_invalid(hass: Any, mock_coordinator: Any):
+    """Test: multiple sensors, one invalid"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        def get_sensor(eid: str) -> dict[str, Any] | None:  # type: ignore
+            if eid == "binary_sensor.virtual_window_sensor_window":
+                return {"entity_id": eid, "enabled": True, const.ATTR_MODES: ["armed_home"]}
+            return None
+        mock_coordinator.store.async_get_sensor.side_effect = get_sensor
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: [
+                "binary_sensor.virtual_window_sensor_window",
+                "binary_sensor.nonexistent"
+            ]
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_called_once_with("binary_sensor.virtual_window_sensor_window", ANY)
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_boolean_flags_only(hass: Any, mock_coordinator: Any):
+    """Test: only boolean flags"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_window_sensor_window",
+            "enabled": True,
+            "always_on": True
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_called_once()
+        args, _ = mock_coordinator.store.async_update_sensor.call_args
+        assert args[1]["enabled"] is True
+        assert args[1]["always_on"] is True
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_modes_friendly_names(hass: Any, mock_coordinator: Any):
+    """Test: modes as friendly names"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_window_sensor_window",
+            const.ATTR_MODES: ["away", "home"]
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_called_once()
+        args, _ = mock_coordinator.store.async_update_sensor.call_args
+        assert set(args[1][const.ATTR_MODES]) == {"armed_away", "armed_home"}
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_modes_internal_names(hass: Any, mock_coordinator: Any):
+    """Test: modes as internal names"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_window_sensor_window",
+            const.ATTR_MODES: ["armed_away", "armed_home"]
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_called_once()
+        args, _ = mock_coordinator.store.async_update_sensor.call_args
+        assert set(args[1][const.ATTR_MODES]) == {"armed_away", "armed_home"}
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_empty_modes(hass: Any, mock_coordinator: Any):
+    """Test: empty modes list (should fail as a sensor must have modes)"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_window_sensor_window",
+            const.ATTR_MODES: []
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_all_parameters(hass: Any, mock_coordinator: Any):
+    """Test: all parameters set"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_window_sensor_window",
+            "type": "door",
+            const.ATTR_MODES: ["armed_away", "armed_home"],
+            "enabled": True,
+            "always_on": True,
+            "use_exit_delay": True,
+            "use_entry_delay": True,
+            "auto_bypass": True,
+            "auto_bypass_modes": ["armed_away"],
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_called_once()
+        args, _ = mock_coordinator.store.async_update_sensor.call_args
+        assert args[1]["type"] == "door"
+        assert set(args[1][const.ATTR_MODES]) == {"armed_away", "armed_home"}
+        assert args[1]["enabled"] is True
+        assert args[1]["always_on"] is True
+        assert args[1]["use_exit_delay"] is True
+        assert args[1]["use_entry_delay"] is True
+        assert args[1]["auto_bypass"] is True
+        assert args[1]["auto_bypass_modes"] == ["armed_away"]
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_extra_unknown_param(hass: Any, mock_coordinator: Any):
+    """Test: extra/unknown parameter (should be rejected)"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_window_sensor_window",
+            "enabled": True,
+            "unknown_param": 123
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_none_modes(hass: Any, mock_coordinator: Any):
+    """Test: modes provided as None (should fail as a sensor must have modes)"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_window_sensor_window",
+            const.ATTR_MODES: None
+        }
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        mock_coordinator.store.async_update_sensor.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_set_sensor_config_unknown_param_rejected(hass: Any, mock_coordinator: Any):
+    """Test: unknown parameter is rejected with vol.PREVENT_EXTRA"""
+    with patch("custom_components.alarmo.sensor_service.async_dispatcher_send"):
+        call = MagicMock()
+        call.data = {
+            const.ATTR_ENTITY_ID: "binary_sensor.virtual_window_sensor_window",
+            "enabled": True,
+            "is_alarmo_sensor_enabled": True  # This is not a valid parameter
+        }
+        
+        await async_service_set_sensor_configuration(hass, call, mock_coordinator)
+        
+        # Verify the sensor was not updated because the unknown param should cause validation to fail
+        # and the error to be handled internally by async_service_set_sensor_configuration.
+        mock_coordinator.store.async_update_sensor.assert_not_called()


### PR DESCRIPTION
Adds the ability to modify Alarmo sensor properties including turning the Alarmo sensor on or off.  These new actions are now available to automations that need to dynamically change properties or temporarily disable or enable an Alarmo sensor while keeping the underlying HA sensor active or otherwise adjust the properties of the Alarmo sensor.

Service data validation is performed before any changes are allowed.  If properties are missing from the service call the properties of the storage are used, allowing one to pass only the properties that need to be modified.  The exception is that the boolean for bypass, if true, must be accompanied by the bypass modes.  Bypass modes are verified against the enabled modes and if they do not align the service call is rejected with an appropriate error.

What this change does not do is update the frontend without a manual refresh of the browser.  For a refresh to automatically occur the frontend needs to listen for a change event which is indeed set by the service backend.

Tests are provided in the test directory (see the comment at the top of the test file).

Developer Note:  The Alarmo repository seems to use CRLF in its files which is not typical and this causes problems for users trying to commit directly from Unix style systems.  This issue might be avoided by adding a .gitattribute file to the repository - see [https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/](https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/)