### PR TITLE
Use a thread pool to check user codes

### DIFF
--- a/custom_components/alarmo/__init__.py
+++ b/custom_components/alarmo/__init__.py
@@ -300,7 +300,7 @@ class AlarmoCoordinator(DataUpdateCoordinator):
             }
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            futures = [executor.submit(check_user_code, user[1], code) for user in users.items()]
+            futures = [executor.submit(check_user_code, user, code) for user in users.values()]
             for future in concurrent.futures.as_completed(futures):
                 if future.result(): return future.result()
         return

--- a/custom_components/alarmo/__init__.py
+++ b/custom_components/alarmo/__init__.py
@@ -128,18 +128,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-def check_user_code(user, code):
-    """Returns the supplied user object if the code matches, None otherwise."""
-    if not user[const.ATTR_ENABLED]:
-        return
-    elif not user[ATTR_CODE] and not code:
-        return user
-    elif user[ATTR_CODE]:
-        hash = base64.b64decode(user[ATTR_CODE])
-        if bcrypt.checkpw(code.encode("utf-8"), hash):
-            return user
-
-
 class AlarmoCoordinator(DataUpdateCoordinator):
     """Define an object to hold Alarmo device."""
 
@@ -294,6 +282,18 @@ class AlarmoCoordinator(DataUpdateCoordinator):
                 self.store.async_update_user(user_id, data)
 
     def async_authenticate_user(self, code: str, user_id: str = None):
+
+        def check_user_code(user, code):
+            """Returns the supplied user object if the code matches, None otherwise."""
+            if not user[const.ATTR_ENABLED]:
+                return
+            elif not user[ATTR_CODE] and not code:
+                return user
+            elif user[ATTR_CODE]:
+                hash = base64.b64decode(user[ATTR_CODE])
+                if bcrypt.checkpw(code.encode("utf-8"), hash):
+                    return user
+            
         if not user_id:
             users = self.store.async_get_users()
         else:

--- a/custom_components/alarmo/__init__.py
+++ b/custom_components/alarmo/__init__.py
@@ -2,6 +2,8 @@
 
 # Max number of threads to start when checking user codes.
 MAX_WORKERS = 4
+# Number of rounds of hashing when computing user hashes.
+BCRYPT_NUM_ROUNDS = 10
 
 import logging
 import bcrypt
@@ -272,7 +274,7 @@ class AlarmoCoordinator(DataUpdateCoordinator):
             data[const.ATTR_CODE_FORMAT] = "number" if data[ATTR_CODE].isdigit() else "text"
             data[const.ATTR_CODE_LENGTH] = len(data[ATTR_CODE])
             hashed = bcrypt.hashpw(
-                data[ATTR_CODE].encode("utf-8"), bcrypt.gensalt(rounds=12)
+                data[ATTR_CODE].encode("utf-8"), bcrypt.gensalt(rounds=BCRYPT_NUM_ROUNDS)
             )
             hashed = base64.b64encode(hashed)
             data[ATTR_CODE] = hashed.decode()

--- a/custom_components/alarmo/__init__.py
+++ b/custom_components/alarmo/__init__.py
@@ -293,7 +293,7 @@ class AlarmoCoordinator(DataUpdateCoordinator):
                 hash = base64.b64decode(user[ATTR_CODE])
                 if bcrypt.checkpw(code.encode("utf-8"), hash):
                     return user
-            
+
         if not user_id:
             users = self.store.async_get_users()
         else:

--- a/custom_components/alarmo/__init__.py
+++ b/custom_components/alarmo/__init__.py
@@ -304,7 +304,9 @@ class AlarmoCoordinator(DataUpdateCoordinator):
         with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
             futures = [executor.submit(check_user_code, user, code) for user in users.values()]
             for future in concurrent.futures.as_completed(futures):
-                if future.result(): return future.result()
+                if future.result():
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    return future.result()
         return
 
     def async_update_automation_config(self, automation_id: str = None, data: dict = {}):


### PR DESCRIPTION
Use multiple threads to check user codes to address slowness when disarming on slow hardware. This fixes https://github.com/nielsfaber/alarmo/issues/1177