### PR TITLE
Update python codebase to replace use of .format() for f-strings in regular string format calls or %s in _LOGGER calls.

### DIFF
--- a/custom_components/alarmo/__init__.py
+++ b/custom_components/alarmo/__init__.py
@@ -341,7 +341,10 @@ class AlarmoCoordinator(DataUpdateCoordinator):
                 _LOGGER.info("Received request for disarming")
                 alarm_entity.alarm_disarm(None, skip_code=True)
             else:
-                _LOGGER.info("Received request for arming with mode {}".format(arm_mode))
+                _LOGGER.info(
+                    "Received request for arming with mode %s", 
+                    arm_mode,
+                )
                 alarm_entity.async_handle_arm_request(arm_mode, skip_code=True)
 
         self._subscriptions.append(
@@ -386,7 +389,11 @@ class AlarmoCoordinator(DataUpdateCoordinator):
             # add sensor to group
             group = self.store.async_get_sensor_group(group_id)
             if not group:
-                _LOGGER.error("Failed to assign entity {} to group {}".format(entity_id, group_id))
+                _LOGGER.error(
+                    "Failed to assign entity %s to group %s",
+                    entity_id,
+                    group_id,
+                )
             elif entity_id not in group[ATTR_ENTITIES]:
                 self.store.async_update_sensor_group(group_id, {
                     ATTR_ENTITIES: group[ATTR_ENTITIES] + [entity_id]
@@ -442,11 +449,19 @@ def register_services(hass):
         users = coordinator.store.async_get_users()
         user = next((item for item in list(users.values()) if item[ATTR_NAME] == name), None)
         if user is None:
-            _LOGGER.warning("Failed to {} user, no match for name '{}'".format("enable" if enable else "disable", name))
+            _LOGGER.warning(
+                "Failed to %s user, no match for name '%s'",
+                "enable" if enable else "disable",
+                name,
+            )
             return
 
         coordinator.store.async_update_user(user[const.ATTR_USER_ID], {const.ATTR_ENABLED: enable})
-        _LOGGER.debug("User user '{}' was {}".format(name, "enabled" if enable else "disabled"))
+        _LOGGER.debug(
+            "User user '%s' was %s",
+            name,
+            "enabled" if enable else "disabled"
+        )
 
     async_register_admin_service(
         hass, const.DOMAIN, const.SERVICE_ENABLE_USER, async_srv_toggle_user, schema=const.SERVICE_TOGGLE_USER_SCHEMA

--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -56,7 +56,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     @callback
     def async_add_alarm_entity(config: dict):
         """Add each entity as Alarm Control Panel."""
-        entity_id = "{}.{}".format(PLATFORM, slugify(config["name"]))
+        entity_id = f"{PLATFORM}.{slugify(config["name"])}"
 
         alarm_entity = AlarmoAreaEntity(
             hass=hass,
@@ -72,8 +72,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     @callback
     def async_add_alarm_master(config: dict):
         """Add each entity as Alarm Control Panel."""
-        entity_id = "{}.{}".format(PLATFORM, slugify(config["name"]))
-
+        entity_id = f"{PLATFORM}.{slugify(config["name"])}"
         alarm_entity = AlarmoMasterEntity(
             hass=hass,
             entity_id=entity_id,
@@ -300,15 +299,24 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
                 for area in ([self.area_id] if self.area_id else list(self.hass.data[const.DOMAIN]["areas"].keys())))
         ):
             # user is not allowed to operate this area
-            _LOGGER.debug("User {} has no permission to arm/disarm this area.".format(res[ATTR_NAME]))
+            _LOGGER.debug(
+                "User %s has no permission to arm/disarm this area.",
+                res[ATTR_NAME],
+            )
             return (False, const.EVENT_INVALID_CODE_PROVIDED)
         elif to_state == AlarmControlPanelState.DISARMED and not res["can_disarm"]:
             # user is not allowed to disarm the alarm
-            _LOGGER.debug("User {} has no permission to disarm the alarm.".format(res[ATTR_NAME]))
+            _LOGGER.debug(
+                "User %s has no permission to disarm the alarm.",
+                res[ATTR_NAME],
+            )
             return (False, const.EVENT_INVALID_CODE_PROVIDED)
         elif to_state in const.ARM_MODES and not res["can_arm"]:
             # user is not allowed to arm the alarm
-            _LOGGER.debug("User {} has no permission to arm the alarm.".format(res[ATTR_NAME]))
+            _LOGGER.debug(
+                "User %s has no permission to arm the alarm.",
+                res[ATTR_NAME],
+            )
             return (False, const.EVENT_INVALID_CODE_PROVIDED)
         else:
             self._changed_by = res[ATTR_NAME]
@@ -335,7 +343,11 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             if not self._config:
                 _LOGGER.warning("Cannot process disarm command, alarm is not initialized yet.")
             else:
-                _LOGGER.warning("Cannot go to state {} from state {}.".format(AlarmControlPanelState.DISARMED, self._state))
+                _LOGGER.warning(
+                    "Cannot go to state %s from state %s.",
+                    AlarmControlPanelState.DISARMED, 
+                    self._state,
+                )
             dispatcher_send(
                 self.hass, "alarmo_event",
                 const.EVENT_COMMAND_NOT_ALLOWED,
@@ -360,9 +372,16 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             self.bypassed_sensors = None
             self.async_update_state(AlarmControlPanelState.DISARMED)
             if self.changed_by:
-                _LOGGER.info("Alarm '{}' is disarmed by {}.".format(self.name, self.changed_by))
+                _LOGGER.info(
+                    "Alarm '%s' is disarmed by %s.",
+                    self.name,
+                    self.changed_by,
+                )
             else:
-                _LOGGER.info("Alarm '{}' is disarmed.".format(self.name))
+                _LOGGER.info(
+                    "Alarm '%s' is disarmed.",
+                    self.name,
+                )
 
             dispatcher_send(self.hass, "alarmo_event", const.EVENT_DISARM, self.area_id, {
                 const.ATTR_CONTEXT_ID: context_id
@@ -402,9 +421,16 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             if not self._config or not self._state:
                 _LOGGER.warning("Cannot process arm command, alarm is not initialized yet.")
             elif not (const.MODES_TO_SUPPORTED_FEATURES[arm_mode] & self.supported_features):
-                _LOGGER.warning("Mode {} is not supported, ignoring.".format(arm_mode))
+                _LOGGER.warning(
+                    "Mode %s is not supported, ignoring.",
+                    arm_mode,
+                )
             else:
-                _LOGGER.warning("Cannot go to state {} from state {}.".format(arm_mode, self._state))
+                _LOGGER.warning(
+                    "Cannot go to state %s from state %s.",
+                    arm_mode,
+                    self._state,
+                )
             dispatcher_send(
                 self.hass, "alarmo_event",
                 const.EVENT_COMMAND_NOT_ALLOWED,
@@ -417,7 +443,10 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             )
             return False
         elif self._state in const.ARM_MODES and self._arm_mode == arm_mode:
-            _LOGGER.debug("Alarm is already set to {}, ignoring command.".format(arm_mode))
+            _LOGGER.debug(
+                "Alarm is already set to %s, ignoring command.",
+                arm_mode,
+            )
             return False
 
         if not skip_code:
@@ -510,7 +539,10 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
 
     async def async_added_to_hass(self):
         """Connect to dispatcher listening for entity data notifications."""
-        _LOGGER.debug("{} is added to hass".format(self.entity_id))
+        _LOGGER.debug(
+            "%s is added to hass",
+            self.entity_id,
+        )
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
@@ -531,7 +563,10 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
 
     async def async_will_remove_from_hass(self):
         await super().async_will_remove_from_hass()
-        _LOGGER.debug("{} is removed from hass".format(self.entity_id))
+        _LOGGER.debug(
+            "%s is removed from hass",
+            self.entity_id,
+        )
 
 
 class AlarmoAreaEntity(AlarmoBaseEntity):
@@ -602,7 +637,11 @@ class AlarmoAreaEntity(AlarmoBaseEntity):
         state = await self.async_get_last_state()
         if state:
             initial_state = state.state
-            _LOGGER.debug("Initial state for {} is {}".format(self.entity_id, initial_state))
+            _LOGGER.debug(
+                "Initial state for %s is %s",
+                self.entity_id,
+                initial_state,
+            )
             if initial_state == AlarmControlPanelState.ARMING:
                 self.async_arm(self.arm_mode)
             elif initial_state == AlarmControlPanelState.PENDING:
@@ -626,7 +665,12 @@ class AlarmoAreaEntity(AlarmoBaseEntity):
         old_state = self._state
         self._state = state
 
-        _LOGGER.debug("entity {} was updated from {} to {}".format(self.entity_id, old_state, state))
+        _LOGGER.debug(
+            "entity %s was updated from %s to %s",
+            self.entity_id,
+            old_state,
+            state,
+        )
 
         if state in const.ARM_MODES + [AlarmControlPanelState.DISARMED]:
             # cancel a running timer that possibly running when transitioning from states arming, pending, triggered
@@ -696,7 +740,9 @@ class AlarmoAreaEntity(AlarmoBaseEntity):
             if open_sensors and not skip_validation:
                 # there where errors -> abort the arm
                 _LOGGER.warning(
-                    "Cannot transition from state {} to state {}, there are open sensors".format(self._state, arm_mode)
+                    "Cannot transition from state %s to state %s, there are open sensors",
+                    self._state,
+                    arm_mode,
                 )
                 self.async_arm_failure(open_sensors, context_id=context_id)
                 return False
@@ -706,9 +752,18 @@ class AlarmoAreaEntity(AlarmoBaseEntity):
                     self.bypassed_sensors = bypassed_sensors
                 self.open_sensors = open_sensors if open_sensors else None
                 if self.changed_by:
-                    _LOGGER.info("Alarm '{}' is armed ({}) by {}.".format(self.name, arm_mode, self.changed_by))
+                    _LOGGER.info(
+                        "Alarm '%s' is armed (%s) by %s.",
+                        self.name,
+                        arm_mode,
+                        self.changed_by,
+                    )
                 else:
-                    _LOGGER.info("Alarm '{}' is armed ({}).".format(self.name, arm_mode))
+                    _LOGGER.info(
+                        "Alarm '%s' is armed (%s).",
+                        self.name,
+                        arm_mode,
+                    )
                 if self._state and self._state != AlarmControlPanelState.ARMING:
                     dispatcher_send(
                         self.hass,
@@ -740,7 +795,10 @@ class AlarmoAreaEntity(AlarmoBaseEntity):
                 return False
             else:
                 # proceed the arm
-                _LOGGER.info("Alarm is now arming. Waiting for {} seconds.".format(exit_delay))
+                _LOGGER.info(
+                    "Alarm is now arming. Waiting for %s seconds.",
+                    exit_delay,
+                )
 
                 @callback
                 def async_leave_timer_finished(now):
@@ -851,7 +909,10 @@ class AlarmoAreaEntity(AlarmoBaseEntity):
 
             self.async_set_timer(entry_delay, async_entry_timer_finished)
             self.delay = entry_delay
-            _LOGGER.info("Alarm will be triggered after {} seconds.".format(entry_delay))
+            _LOGGER.info(
+                "Alarm will be triggered after %s seconds.",
+                entry_delay,
+            )
 
             self.async_update_state(AlarmControlPanelState.PENDING)
 
@@ -876,7 +937,11 @@ class AlarmoAreaEntity(AlarmoBaseEntity):
         """Set arm modes which are ready for arming (no blocking sensors)."""
         if value == self._ready_to_arm_modes:
             return
-        _LOGGER.debug("ready_to_arm_modes for {} updated to {}".format(self.name, ", ".join(value).replace("armed_","")))
+        _LOGGER.debug(
+            "ready_to_arm_modes for %s updated to %s",
+            self.name,
+            ", ".join(value).replace("armed_",""),
+        )
         self._ready_to_arm_modes = value
         dispatcher_send(self.hass, "alarmo_event", const.EVENT_READY_TO_ARM_MODES_CHANGED, self.area_id, {
             const.ATTR_MODES: value
@@ -1068,7 +1133,12 @@ class AlarmoMasterEntity(AlarmoBaseEntity):
             old_state = self._state
 
             self._state = state
-            _LOGGER.debug("entity {} was updated from {} to {}".format(self.entity_id, old_state, state))
+            _LOGGER.debug(
+                "entity %s was updated from %s to %s",
+                self.entity_id,
+                old_state,
+                state,
+            )
             dispatcher_send(self.hass, "alarmo_state_updated", None, old_state, state)
 
             if state == AlarmControlPanelState.TRIGGERED:
@@ -1186,7 +1256,10 @@ class AlarmoMasterEntity(AlarmoBaseEntity):
         if modes_list == self._ready_to_arm_modes:
             return
         self._ready_to_arm_modes = modes_list
-        _LOGGER.debug("ready_to_arm_modes for master updated to {}".format(", ".join(modes_list).replace("armed_","")))
+        _LOGGER.debug(
+            "ready_to_arm_modes for master updated to %s",
+            ", ".join(modes_list).replace("armed_",""),
+        )
         dispatcher_send(self.hass, "alarmo_event", const.EVENT_READY_TO_ARM_MODES_CHANGED, self.area_id, {
             const.ATTR_MODES: modes_list
         })

--- a/custom_components/alarmo/automations.py
+++ b/custom_components/alarmo/automations.py
@@ -104,7 +104,12 @@ class AutomationHandler:
             if not alarm_entity:
                 return
 
-            _LOGGER.debug("state of {} is updated from {} to {}".format(alarm_entity.entity_id, old_state, new_state))
+            _LOGGER.debug(
+                "state of %s is updated from %s to %s",
+                alarm_entity.entity_id,
+                old_state,
+                new_state,
+            )
 
             if new_state in const.ARM_MODES:
                 # we don't distinguish between armed modes for automations, they are handled separately
@@ -134,7 +139,10 @@ class AutomationHandler:
             else:
                 alarm_entity = self.hass.data[const.DOMAIN]["master"]
 
-            _LOGGER.debug("{} has failed to arm".format(alarm_entity.entity_id))
+            _LOGGER.debug(
+                "%s has failed to arm",
+                alarm_entity.entity_id,
+            )
 
             for automation_id, config in self._config.items():
                 if not config[const.ATTR_ENABLED]:
@@ -158,7 +166,10 @@ class AutomationHandler:
 
     async def async_execute_automation(self, automation_id: str, alarm_entity: AlarmoBaseEntity):
         # automation is a dict of AutomationEntry
-        _LOGGER.debug("Executing automation {}".format(automation_id))
+        _LOGGER.debug(
+            "Executing automation %s",
+            automation_id,
+        )
 
         actions = self._config[automation_id][const.ATTR_ACTIONS]
         for action in actions:
@@ -191,7 +202,11 @@ class AutomationHandler:
                     )
                 )
             except HomeAssistantError as e:
-                _LOGGER.error("Execution of action {} failed, reason: {}".format(automation_id, e))
+                _LOGGER.error(
+                    "Execution of action %s failed, reason: %s",
+                    automation_id,
+                    e,
+                )
 
     def get_automations_by_area(self, area_id: str):
         result = []
@@ -280,17 +295,21 @@ class AutomationHandler:
         device_type = entity.attributes["device_class"] if entity and "device_class" in entity.attributes else None
 
         if state == STATE_OPEN:
-            translation_key = "component.binary_sensor.device_automation.condition_type.{}".format(
-                ENTITY_CONDITIONS[device_type][0]["type"]
-            ) if device_type in ENTITY_CONDITIONS else None
+            translation_key = (
+                f"component.binary_sensor.device_automation.condition_type.{ENTITY_CONDITIONS[device_type][0]["type"]}" 
+                if device_type in ENTITY_CONDITIONS 
+                else None
+            )
             if translation_key and translation_key in translations:
                 string = translations[translation_key]
             else:
                 string = "{entity_name} is open"
         elif state == STATE_CLOSED:
-            translation_key = "component.binary_sensor.device_automation.condition_type.{}".format(
-                ENTITY_CONDITIONS[device_type][1]["type"]
-            ) if device_type in ENTITY_CONDITIONS else None
+            translation_key = (
+                f"component.binary_sensor.device_automation.condition_type.{ENTITY_CONDITIONS[device_type][1]["type"]}"
+                if device_type in ENTITY_CONDITIONS 
+                else None
+            )
             if translation_key and translation_key in translations:
                 string = translations[translation_key]
             else:
@@ -326,8 +345,10 @@ class AutomationHandler:
             self._alarmTranslationLang = language
 
         translation_key = (
-            "component.alarm_control_panel.entity_component._.state.{}".format(arm_mode)
-        ) if arm_mode else None
+            f"component.alarm_control_panel.entity_component._.state.{arm_mode}"
+            if arm_mode 
+            else None
+        ) 
 
         if translation_key and translation_key in translations:
             return translations[translation_key]

--- a/custom_components/alarmo/mqtt.py
+++ b/custom_components/alarmo/mqtt.py
@@ -81,7 +81,11 @@ class MqttHandler:
                 message = new_state
 
             hass.async_create_task(mqtt.async_publish(self.hass, topic, message, retain=True))
-            _LOGGER.debug("Published state '{}' on topic '{}'".format(message, topic))
+            _LOGGER.debug(
+                "Published state '%s' on topic '%s'",
+                message,
+                topic,
+            )
 
         self._subscriptions.append(
             async_dispatcher_connect(self.hass, "alarmo_state_updated", async_alarm_state_changed)
@@ -107,10 +111,7 @@ class MqttHandler:
 
             if event == const.EVENT_ARM:
                 payload = {
-                    "event": "{}_{}".format(
-                        event.upper(),
-                        args["arm_mode"].split("_", 1).pop(1).upper()
-                    ),
+                    "event": f"{event.upper()}_{args["arm_mode"].split("_", 1).pop(1).upper()}",
                     "delay": args["delay"],
                 }
             elif event == const.EVENT_TRIGGER:
@@ -181,7 +182,10 @@ class MqttHandler:
                     self.async_message_received,
                 )
         )
-        _LOGGER.debug("Subscribed to topic {}".format(self._config[ATTR_MQTT][CONF_COMMAND_TOPIC]))
+        _LOGGER.debug(
+            "Subscribed to topic %s",
+            self._config[ATTR_MQTT][CONF_COMMAND_TOPIC],
+        )
 
     @callback
     async def async_message_received(self, msg):
@@ -251,7 +255,10 @@ class MqttHandler:
         if area:
             res = list(filter(lambda el: slugify(el.name) == area, self.hass.data[const.DOMAIN]["areas"].values()))
             if not res:
-                _LOGGER.warning("Area {} does not exist".format(area))
+                _LOGGER.warning(
+                    "Area %s does not exist",
+                    area,
+                )
                 return
             entity = res[0]
         else:
@@ -263,7 +270,10 @@ class MqttHandler:
                 _LOGGER.warning("No area specified")
                 return
 
-        _LOGGER.debug("Received command {}".format(command))
+        _LOGGER.debug(
+            "Received command %s",
+            command,
+        )
 
         if command == command_payloads[const.COMMAND_DISARM]:
             entity.alarm_disarm(code, skip_code=skip_code)

--- a/custom_components/alarmo/sensors.py
+++ b/custom_components/alarmo/sensors.py
@@ -191,7 +191,11 @@ class SensorHandler:
                 state = self.hass.states.get(entity)
                 sensor_state = parse_sensor_state(state)
                 if state and state.state and sensor_state != STATE_UNKNOWN:
-                    _LOGGER.debug("Initial state for {} is {}".format(entity, parse_sensor_state(state)))
+                    _LOGGER.debug(
+                        "Initial state for %s is %s",
+                        entity,
+                        parse_sensor_state(state),
+                    )
 
         if area_id:
             self.update_ready_to_arm_status(area_id)
@@ -274,14 +278,23 @@ class SensorHandler:
         sensor_config = self._config[entity]
         if old_state == STATE_UNKNOWN:
             # sensor is unknown at startup, state which comes after is considered as initial state
-            _LOGGER.debug("Initial state for {} is {}".format(entity, new_state))
+            _LOGGER.debug(
+                "Initial state for %s is %s",
+                entity,
+                new_state,
+            )
             self.update_ready_to_arm_status(sensor_config["area"])
             return
         if old_state == new_state:
             # not a state change - ignore
             return
 
-        _LOGGER.debug("entity {} changed: old_state={}, new_state={}".format(entity, old_state, new_state))
+        _LOGGER.debug(
+            "entity %s changed: old_state=%s, new_state=%s",
+            entity,
+            old_state,
+            new_state,
+        )
 
         alarm_entity = self.hass.data[const.DOMAIN]["areas"][sensor_config["area"]]
         alarm_state = alarm_entity.state
@@ -317,7 +330,10 @@ class SensorHandler:
 
         if sensor_config[ATTR_ALWAYS_ON]:
             # immediate trigger due to always on sensor
-            _LOGGER.info("Alarm is triggered due to an always-on sensor: {}".format(entity))
+            _LOGGER.info(
+                "Alarm is triggered due to an always-on sensor: %s",
+                entity,
+            )
             alarm_entity.async_trigger(
                 skip_delay=True,
                 open_sensors=open_sensors
@@ -325,12 +341,18 @@ class SensorHandler:
 
         elif alarm_state == AlarmControlPanelState.ARMING:
             # sensor triggered while arming, abort arming
-            _LOGGER.debug("Arming was aborted due to a sensor being active: {}".format(entity))
+            _LOGGER.debug(
+                "Arming was aborted due to a sensor being active: %s",
+                entity,
+            )
             alarm_entity.async_arm_failure(open_sensors)
 
         elif alarm_state in const.ARM_MODES:
             # standard alarm trigger
-            _LOGGER.info("Alarm is triggered due to sensor: {}".format(entity))
+            _LOGGER.info(
+                "Alarm is triggered due to sensor: %s",
+                entity,
+            )
             alarm_entity.async_trigger(
                 skip_delay=(not sensor_config[ATTR_USE_ENTRY_DELAY]),
                 open_sensors=open_sensors
@@ -338,7 +360,10 @@ class SensorHandler:
 
         elif alarm_state == AlarmControlPanelState.PENDING:
             # immediate trigger while in pending state
-            _LOGGER.info("Alarm is triggered due to sensor: {}".format(entity))
+            _LOGGER.info(
+                "Alarm is triggered due to sensor: %s",
+                entity,
+            )
             alarm_entity.async_trigger(
                 skip_delay=True,
                 open_sensors=open_sensors
@@ -402,12 +427,20 @@ class SensorHandler:
         }
         recent_events = dict(filter(lambda el: el[1] <= group[ATTR_TIMEOUT], recent_events.items()))
         if len(recent_events.keys()) < group[ATTR_EVENT_COUNT]:
-            _LOGGER.debug("tripped sensor {} was ignored since it belongs to group {}".format(entity, group[ATTR_NAME]))
+            _LOGGER.debug(
+                "tripped sensor %s was ignored since it belongs to group %s",
+                entity,
+                group[ATTR_NAME],
+            )
             return {}
         else:
             for entity in recent_events.keys():
                 open_sensors[entity] = group_events[entity][ATTR_STATE]
-            _LOGGER.debug("tripped sensor {} caused the triggering of group {}".format(entity, group[ATTR_NAME]))
+            _LOGGER.debug(
+                "tripped sensor %s caused the triggering of group %s",
+                entity, 
+                group[ATTR_NAME],
+            )
             return open_sensors
 
     def update_ready_to_arm_status(self, area_id):


### PR DESCRIPTION
I noticed that the codebase was using .format() for string formatting.

I refactored all _LOGGER calls to use %s string formatting, the logging module technically supports .format() and f-strings, but it's actually less efficient to use them. basically, you end up pre-parsing your string before passing the data to the logging module, rather than letting the logging module handle the concatenation under the hood (since it handles concatenation of variables using the %s syntax) 

I also refactored .format() calls not inside of _LOGGER calls to f-string since f-strings are easier to read, faster than .format() calls, and newer (introduced in Python 3.6)

References:
[https://docs.python.org/3/howto/logging.html#logging-variable-data](url)
[https://peps.python.org/pep-0498/](url)
[https://blog.finxter.com/string-formatting-vs-format-vs-formatted-string-literal/](url)
