### PR TITLE
Validate user name and code before creating/updating users

### DIFF
--- a/custom_components/alarmo/__init__.py
+++ b/custom_components/alarmo/__init__.py
@@ -252,11 +252,42 @@ class AlarmoCoordinator(DataUpdateCoordinator):
 
         async_dispatcher_send(self.hass, "alarmo_sensors_updated")
 
-    def async_update_user_config(self, user_id: str = None, data: dict = {}):
+    def _validate_user_code(self, user_id: str, data: dict):
+        user_with_code = self.async_authenticate_user(data[ATTR_CODE])
+        if user_id:
+            if const.ATTR_OLD_CODE not in data:
+                _LOGGER.error("Not updating user: Code missing")
+                return False
+            if not self.async_authenticate_user(data[const.ATTR_OLD_CODE], user_id):
+                _LOGGER.error("Not updating user: Wrong code provided")
+                return False
+            if user_with_code and user_with_code[const.ATTR_USER_ID] != user_id:
+                _LOGGER.error("Not updating user: User with same code already exists")
+                return False
+        elif user_with_code:
+            _LOGGER.error("Not creating user: User with same code already exists")
+            return False
+        return True
 
+    def _validate_user_name(self, user_id: str, data: dict):
+        if not data[ATTR_NAME]:
+            _LOGGER.error("User name must not be empty")
+            return False
+        for user in self.store.async_get_users().values():
+            if data[ATTR_NAME] == user[ATTR_NAME] and user_id != user[const.ATTR_USER_ID]:
+                _LOGGER.error("User with same name already exists")
+                return False
+        return True
+
+    def async_update_user_config(self, user_id: str = None, data: dict = {}):
         if const.ATTR_REMOVE in data:
             self.store.async_delete_user(user_id)
-            return
+            return True
+
+        if not self._validate_user_name(user_id, data):
+            return False
+        if ATTR_CODE in data and not self._validate_user_code(user_id, data):
+            return False
 
         if ATTR_CODE in data and data[ATTR_CODE]:
             data[const.ATTR_CODE_FORMAT] = "number" if data[ATTR_CODE].isdigit() else "text"
@@ -271,15 +302,8 @@ class AlarmoCoordinator(DataUpdateCoordinator):
             self.store.async_create_user(data)
         else:
             if ATTR_CODE in data:
-                if const.ATTR_OLD_CODE not in data:
-                    return False
-                elif not self.async_authenticate_user(data[const.ATTR_OLD_CODE], user_id):
-                    return False
-                else:
-                    del data[const.ATTR_OLD_CODE]
-                    self.store.async_update_user(user_id, data)
-            else:
-                self.store.async_update_user(user_id, data)
+                del data[const.ATTR_OLD_CODE]
+            self.store.async_update_user(user_id, data)
 
     def async_authenticate_user(self, code: str, user_id: str = None):
 


### PR DESCRIPTION
Proposed fix for [1183](https://github.com/nielsfaber/alarmo/issues/1183).

Note that attempts to create users with conflicting codes or names will silently fail as this pull request doesn't include any UI changes. I've added some logging to give some indication of what's happening.