### PR TITLE
feat: add support for sending SIA codes to remote

### DIFF
--- a/custom_components/alarmo/__init__.py
+++ b/custom_components/alarmo/__init__.py
@@ -48,6 +48,7 @@ from .sensors import (
 from .automations import AutomationHandler
 from .mqtt import MqttHandler
 from .event import EventHandler
+from .sia import SIAHandler
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -159,6 +160,11 @@ class AlarmoCoordinator(DataUpdateCoordinator):
         self.hass.data[const.DOMAIN]["automation_handler"] = AutomationHandler(self.hass)
         self.hass.data[const.DOMAIN]["mqtt_handler"] = MqttHandler(self.hass)
         self.hass.data[const.DOMAIN]["event_handler"] = EventHandler(self.hass)
+
+        # Initialize SIA handler
+        sia_handler = SIAHandler(self.hass)
+        self.hass.data[const.DOMAIN]["sia_handler"] = sia_handler
+        self.hass.async_create_task(sia_handler.async_initialize())
 
         areas = self.store.async_get_areas()
         config = self.store.async_get_config()

--- a/custom_components/alarmo/const.py
+++ b/custom_components/alarmo/const.py
@@ -145,6 +145,37 @@ ATTR_CONTEXT_ID = "context_id"
 
 PUSH_EVENT = "mobile_app_notification_action"
 
+# Configuration Keys
+ATTR_SIA = "sia"
+
+# SIA Configuration Constants
+CONF_SIA_ENABLED = "sia_enabled"
+CONF_SIA_HOST = "sia_host"
+CONF_SIA_PORT = "sia_port"
+CONF_SIA_ACCOUNT = "sia_account"
+CONF_SIA_ENCRYPTION_KEY = "sia_encryption_key"
+CONF_SIA_PROTOCOL = "sia_protocol"
+CONF_SIA_RECEIVER_ID = "sia_receiver_id"
+CONF_SIA_LINE_ID = "sia_line_id"
+CONF_SIA_SECONDARY_HOST = "sia_secondary_host"
+CONF_SIA_SECONDARY_PORT = "sia_secondary_port"
+CONF_SIA_CONNECTION_MODE = "sia_connection_mode"
+CONF_SIA_HEARTBEAT_INTERVAL = "sia_heartbeat_interval"
+CONF_SIA_RETRY_COUNT = "sia_retry_count"
+CONF_SIA_RETRY_DELAY = "sia_retry_delay"
+CONF_SIA_TIMEOUT = "sia_timeout"
+CONF_SIA_EVENT_FILTER = "sia_event_filter"
+CONF_SIA_AREA_FILTER = "sia_area_filter"
+
+# SIA Protocol Options
+SIA_PROTOCOL_TCP = "TCP"
+SIA_PROTOCOL_UDP = "UDP"
+SIA_PROTOCOLS = [SIA_PROTOCOL_TCP, SIA_PROTOCOL_UDP]
+
+SIA_CONNECTION_ON_DEMAND = "on_demand"
+SIA_CONNECTION_PERSISTENT = "persistent"
+SIA_CONNECTION_MODES = [SIA_CONNECTION_ON_DEMAND, SIA_CONNECTION_PERSISTENT]
+
 EVENT_ACTION_FORCE_ARM = "ALARMO_FORCE_ARM"
 EVENT_ACTION_RETRY_ARM = "ALARMO_RETRY_ARM"
 EVENT_ACTION_DISARM = "ALARMO_DISARM"

--- a/custom_components/alarmo/frontend/src/types.ts
+++ b/custom_components/alarmo/frontend/src/types.ts
@@ -94,6 +94,7 @@ export type AlarmoConfig = {
   disarm_after_trigger: boolean;
   ignore_blocking_sensors_after_trigger: boolean;
   mqtt: MqttConfig;
+  sia: SiaConfig;
   master: MasterConfig;
 };
 
@@ -169,6 +170,26 @@ export type MqttConfig = {
   command_payload: Dictionary<string>;
   require_code: boolean;
   event_topic: string;
+};
+
+export type SiaConfig = {
+  enabled: boolean;
+  host: string;
+  port: number;
+  protocol: string;
+  account: string;
+  encryption_key: string;
+  receiver_id: string;
+  line_id: string;
+  secondary_host: string;
+  secondary_port: number;
+  connection_mode: string;
+  heartbeat_interval: number;
+  retry_count: number;
+  retry_delay: number;
+  timeout: number;
+  event_filter: string[];
+  area_filter: string[];
 };
 
 export type MasterConfig = {

--- a/custom_components/alarmo/sia.py
+++ b/custom_components/alarmo/sia.py
@@ -1,0 +1,426 @@
+"""SIA (Security Industry Association) DC-09 protocol implementation for Alarmo."""
+
+import asyncio
+import json
+import logging
+import socket
+import time
+from datetime import datetime
+from typing import Optional, Dict, Any, Tuple
+
+import crcmod
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.backends import default_backend
+
+from homeassistant.core import (
+    HomeAssistant,
+    callback,
+)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.storage import Store
+from homeassistant.util import slugify
+
+from . import const
+from .helpers import friendly_name_for_entity_id
+
+_LOGGER = logging.getLogger(__name__)
+
+# SIA Protocol Constants
+SIA_MESSAGE_TYPE = "SIA-DCS"
+SIA_SEQUENCE_MIN = 1
+SIA_SEQUENCE_MAX = 9999
+SIA_STORAGE_VERSION = 1
+SIA_STORAGE_KEY = "alarmo_sia_state"
+
+# Default ports
+SIA_DEFAULT_TCP_PORT = 50001
+SIA_DEFAULT_UDP_PORT = 10200
+
+# Connection timeouts
+SIA_DEFAULT_TIMEOUT = 30
+SIA_DEFAULT_RETRY_COUNT = 3
+SIA_DEFAULT_RETRY_DELAY = 5
+
+
+class SIAHandler:
+    """Handle SIA DC-09 protocol communication."""
+
+    def __init__(self, hass: HomeAssistant):
+        """Initialize SIA handler."""
+        self.hass = hass
+        self._config = None
+        self._subscriptions = []
+        self._sequence_number = 1
+        self._storage = Store(hass, SIA_STORAGE_VERSION, SIA_STORAGE_KEY)
+
+        # Initialize CRC function (CRC-16 CCITT)
+        self._crc_func = crcmod.predefined.mkCrcFun('crc-ccitt-false')
+
+        @callback
+        def async_update_config(_args=None):
+            """SIA config updated, reload the configuration."""
+            old_config = self._config
+
+            # Get SIA config from Alarmo store
+            coordinator = self.hass.data[const.DOMAIN]["coordinator"]
+            store_config = coordinator.store.async_get_config()
+            new_config = {const.ATTR_SIA: store_config.get(const.ATTR_SIA, {})}
+
+            if old_config and old_config.get(const.ATTR_SIA, {}) == new_config.get(const.ATTR_SIA, {}):
+                # only update SIA config if some parameters are changed
+                return
+
+            self._config = new_config
+            _LOGGER.debug("SIA config was (re)loaded")
+
+        self._subscriptions.append(
+            async_dispatcher_connect(hass, "alarmo_config_updated", async_update_config)
+        )
+
+        # Also listen for config entry updates
+        @callback
+        def async_entry_updated():
+            """Handle config entry updates."""
+            async_update_config()
+
+        self._subscriptions.append(
+            async_dispatcher_connect(hass, f"alarmo_entry_updated", async_entry_updated)
+        )
+
+        async_update_config()
+
+        @callback
+        def async_handle_event(event: str, area_id: str, args: dict = {}):
+            """Handle Alarmo events and send SIA messages."""
+            if not self._config or not self._config.get(const.ATTR_SIA, {}).get("enabled", False):
+                return
+
+            # Schedule async SIA message transmission
+            hass.async_create_task(self._async_send_sia_event(event, area_id, args))
+
+        self._subscriptions.append(
+            async_dispatcher_connect(self.hass, "alarmo_event", async_handle_event)
+        )
+
+    def __del__(self):
+        """Class destructor."""
+        for subscription in self._subscriptions:
+            subscription()
+
+    async def async_initialize(self):
+        """Initialize SIA handler with stored state."""
+        try:
+            stored_data = await self._storage.async_load()
+            if stored_data:
+                self._sequence_number = stored_data.get("sequence_number", 1)
+        except Exception as err:
+            _LOGGER.warning("Failed to load SIA storage: %s", err)
+            self._sequence_number = 1
+
+    async def _async_save_state(self):
+        """Save SIA state to storage."""
+        try:
+            await self._storage.async_save({
+                "sequence_number": self._sequence_number
+            })
+        except Exception as err:
+            _LOGGER.warning("Failed to save SIA storage: %s", err)
+
+    def _get_next_sequence(self) -> str:
+        """Get next sequence number and increment."""
+        sequence = self._sequence_number
+        self._sequence_number += 1
+        if self._sequence_number > SIA_SEQUENCE_MAX:
+            self._sequence_number = SIA_SEQUENCE_MIN
+
+        # Schedule save of new sequence number
+        self.hass.async_create_task(self._async_save_state())
+
+        return f"{sequence:04d}"
+
+    def _event_to_sia_code(self, event: str, area_id: str, args: dict) -> Tuple[str, str]:
+        """Convert Alarmo event to SIA event code and description."""
+        # Get sensor information from args if available
+        sensor_entity_id = args.get("sensor_entity_id")
+        sensor_name = ""
+
+        if sensor_entity_id:
+            sensor_name = friendly_name_for_entity_id(self.hass, sensor_entity_id)
+            entity = self.hass.states.get(sensor_entity_id)
+            device_class = entity.attributes.get("device_class") if entity else None
+        else:
+            device_class = None
+
+        # Map Alarmo events to SIA codes
+        if event == const.EVENT_ARM:
+            arm_mode = args.get("arm_mode", "")
+            if "away" in arm_mode:
+                return "CL", f"Armed Away - {self._get_area_name(area_id)}"
+            elif "home" in arm_mode:
+                return "CL", f"Armed Home - {self._get_area_name(area_id)}"
+            elif "night" in arm_mode:
+                return "CL", f"Armed Night - {self._get_area_name(area_id)}"
+            else:
+                return "CL", f"Armed - {self._get_area_name(area_id)}"
+
+        elif event == const.EVENT_DISARM:
+            return "OP", f"Disarmed - {self._get_area_name(area_id)}"
+
+        elif event == const.EVENT_TRIGGER:
+            # Determine SIA code based on sensor type/device class
+            if device_class == "smoke" or "smoke" in (sensor_name or "").lower():
+                return "FA", f"Fire Alarm - {sensor_name}"
+            elif device_class == "gas" or device_class == "carbon_monoxide":
+                return "GA", f"Gas Alarm - {sensor_name}"
+            elif device_class == "moisture" or "water" in (sensor_name or "").lower():
+                return "WA", f"Water Alarm - {sensor_name}"
+            elif device_class == "heat":
+                return "KA", f"Heat Alarm - {sensor_name}"
+            elif device_class == "door" or device_class == "window" or device_class == "opening":
+                return "BA", f"Burglary Alarm - {sensor_name}"
+            elif device_class == "motion" or device_class == "occupancy":
+                return "BA", f"Motion Alarm - {sensor_name}"
+            elif device_class == "vibration" or "tamper" in (sensor_name or "").lower():
+                return "TA", f"Tamper Alarm - {sensor_name}"
+            else:
+                return "BA", f"Burglary Alarm - {sensor_name or 'Unknown Sensor'}"
+
+        elif event == const.EVENT_FAILED_TO_ARM:
+            return "CF", f"Failed to Arm - {self._get_area_name(area_id)}"
+
+        elif event == const.EVENT_ENTRY:
+            return "BD", f"Entry Delay - {sensor_name}"
+
+        elif event == const.EVENT_LEAVE:
+            return "CL", f"Exit Delay - {self._get_area_name(area_id)}"
+
+        elif event == const.EVENT_TRIGGER_TIME_EXPIRED:
+            return "BC", f"Alarm Cancelled - {self._get_area_name(area_id)}"
+
+        else:
+            return "YS", f"System Event - {event}"
+
+    def _get_area_name(self, area_id: str) -> str:
+        """Get area name from area_id."""
+        if not area_id:
+            return "Master"
+
+        try:
+            if area_id in self.hass.data[const.DOMAIN]["areas"]:
+                area_entity = self.hass.data[const.DOMAIN]["areas"][area_id]
+                return area_entity.name
+            else:
+                return f"Area {area_id}"
+        except Exception:
+            return f"Area {area_id}"
+
+    def _get_area_ri_value(self, area_id: str) -> str:
+        """Get ri value for area (zone number)."""
+        if not area_id:
+            return "000"  # Master area
+
+        # Extract number from area_id (e.g., "area_1" -> "001")
+        try:
+            area_num = int(area_id.split("_")[-1])
+            return f"{area_num:03d}"
+        except (ValueError, IndexError):
+            return "001"
+
+    def _calculate_crc(self, message: str) -> str:
+        """Calculate CRC checksum for SIA message."""
+        crc = self._crc_func(message.encode('ascii'))
+        return f"{crc:04X}"
+
+    def _encrypt_message(self, message: str, key: str) -> str:
+        """Encrypt SIA message content using AES."""
+        if not key:
+            return message
+
+        try:
+            # Pad key to required length (16, 24, or 32 bytes)
+            key_bytes = key.encode('ascii')
+            if len(key_bytes) <= 16:
+                key_bytes = key_bytes.ljust(16, b'\0')
+            elif len(key_bytes) <= 24:
+                key_bytes = key_bytes.ljust(24, b'\0')
+            else:
+                key_bytes = key_bytes[:32].ljust(32, b'\0')
+
+            # Generate IV (initialization vector)
+            iv = b'\0' * 16  # Simple IV for now, should be random in production
+
+            # Pad message to AES block size
+            padder = padding.PKCS7(128).padder()
+            padded_data = padder.update(message.encode('ascii'))
+            padded_data += padder.finalize()
+
+            # Encrypt
+            cipher = Cipher(algorithms.AES(key_bytes), modes.CBC(iv), backend=default_backend())
+            encryptor = cipher.encryptor()
+            encrypted = encryptor.update(padded_data) + encryptor.finalize()
+
+            # Return hex-encoded encrypted data
+            return encrypted.hex().upper()
+
+        except Exception as err:
+            _LOGGER.error("Failed to encrypt SIA message: %s", err)
+            return message
+
+    def _build_sia_message(self, event_code: str, description: str, area_id: str) -> str:
+        """Build complete SIA DC-09 message."""
+        sia_config = self._config.get(const.ATTR_SIA, {})
+
+        # Message components
+        sequence = self._get_next_sequence()
+        timestamp = datetime.now().strftime("%H:%M:%S,%m-%d-%Y")
+        ri_value = self._get_area_ri_value(area_id)
+        account = sia_config.get("account", "FFFF")
+        receiver_id = sia_config.get("receiver_id", "R000A")
+        line_id = sia_config.get("line_id", "L001")
+        encryption_key = sia_config.get("encryption_key", "")
+
+        # Build content
+        content = f"#{account}|Nri{ri_value}{event_code}[{description}]_{timestamp}"
+
+        # Encrypt if key provided
+        encrypted = False
+        if encryption_key:
+            content = self._encrypt_message(content, encryption_key)
+            encrypted = True
+
+        # Build message without CRC and length
+        message_body = f'"{SIA_MESSAGE_TYPE}"{sequence}{receiver_id}{line_id}{content}'
+        if encrypted:
+            message_body = f'"*{SIA_MESSAGE_TYPE}"{sequence}{receiver_id}{line_id}{content}'
+
+        # Calculate length
+        length = len(message_body) + 8  # +8 for CRC and length fields
+        length_hex = f"{length:04X}"
+
+        # Calculate CRC over entire message including length
+        crc_input = length_hex + message_body
+        crc = self._calculate_crc(crc_input)
+
+        # Final message
+        final_message = crc + length_hex + message_body
+
+        _LOGGER.debug("Built SIA message: %s", final_message)
+        return final_message
+
+    async def _async_send_sia_event(self, event: str, area_id: str, args: dict):
+        """Send SIA message for Alarmo event."""
+        try:
+            sia_config = self._config.get(const.ATTR_SIA, {})
+
+            # Check if event should be filtered
+            event_filter = sia_config.get("event_filter", [])
+            if event_filter and event not in event_filter:
+                return
+
+            # Check if area should be filtered
+            area_filter = sia_config.get("area_filter", [])
+            if area_filter and area_id not in area_filter:
+                return
+
+            # Convert event to SIA code
+            sia_code, description = self._event_to_sia_code(event, area_id, args)
+
+            # Build SIA message
+            message = self._build_sia_message(sia_code, description, area_id)
+
+            # Send message
+            await self._async_transmit_message(message)
+
+        except Exception as err:
+            _LOGGER.error("Failed to send SIA event: %s", err)
+
+    async def _async_transmit_message(self, message: str):
+        """Transmit SIA message to monitoring station."""
+        sia_config = self._config.get(const.ATTR_SIA, {})
+
+        host = sia_config.get("host")
+        port = sia_config.get("port", SIA_DEFAULT_TCP_PORT)
+        protocol = sia_config.get("protocol", "TCP").upper()
+        timeout = sia_config.get("timeout", SIA_DEFAULT_TIMEOUT)
+        retry_count = sia_config.get("retry_count", SIA_DEFAULT_RETRY_COUNT)
+        retry_delay = sia_config.get("retry_delay", SIA_DEFAULT_RETRY_DELAY)
+
+        if not host:
+            _LOGGER.warning("SIA host not configured, cannot send message")
+            return
+
+        for attempt in range(retry_count + 1):
+            try:
+                if protocol == "TCP":
+                    await self._async_send_tcp(host, port, message, timeout)
+                else:
+                    await self._async_send_udp(host, port, message, timeout)
+
+                _LOGGER.info("SIA message sent successfully to %s:%s", host, port)
+                return
+
+            except Exception as err:
+                _LOGGER.warning("SIA transmission attempt %d failed: %s", attempt + 1, err)
+                if attempt < retry_count:
+                    await asyncio.sleep(retry_delay)
+                else:
+                    _LOGGER.error("SIA transmission failed after %d attempts", retry_count + 1)
+
+    async def _async_send_tcp(self, host: str, port: int, message: str, timeout: int):
+        """Send SIA message via TCP."""
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port),
+            timeout=timeout
+        )
+
+        try:
+            # Send message
+            writer.write(message.encode('ascii'))
+            await writer.drain()
+
+            # Wait for response
+            response = await asyncio.wait_for(reader.read(1024), timeout=5)
+            response_str = response.decode('ascii').strip()
+
+            _LOGGER.debug("SIA TCP response: %s", response_str)
+
+            if "ACK" not in response_str:
+                _LOGGER.warning("SIA message not acknowledged: %s", response_str)
+
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def _async_send_udp(self, host: str, port: int, message: str, timeout: int):
+        """Send SIA message via UDP."""
+        loop = asyncio.get_event_loop()
+
+        # Create UDP socket
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.settimeout(timeout)
+
+        try:
+            # Send message
+            await loop.run_in_executor(
+                None, sock.sendto, message.encode('ascii'), (host, port)
+            )
+
+            # Wait for response (optional for UDP)
+            try:
+                response, addr = await asyncio.wait_for(
+                    loop.run_in_executor(None, sock.recvfrom, 1024),
+                    timeout=5
+                )
+                response_str = response.decode('ascii').strip()
+                _LOGGER.debug("SIA UDP response: %s", response_str)
+
+                if "ACK" not in response_str:
+                    _LOGGER.warning("SIA message not acknowledged: %s", response_str)
+
+            except asyncio.TimeoutError:
+                # UDP response is optional
+                _LOGGER.debug("No UDP response received (this is normal for UDP)")
+
+        finally:
+            sock.close()

--- a/custom_components/alarmo/store.py
+++ b/custom_components/alarmo/store.py
@@ -49,6 +49,29 @@ class MqttConfig:
 
 
 @attr.s(slots=True, frozen=True)
+class SiaConfig:
+    """SIA storage Entry."""
+
+    enabled = attr.ib(type=bool, default=False)
+    host = attr.ib(type=str, default="")
+    port = attr.ib(type=int, default=50001)
+    protocol = attr.ib(type=str, default="TCP")
+    account = attr.ib(type=str, default="")
+    encryption_key = attr.ib(type=str, default="")
+    receiver_id = attr.ib(type=str, default="R000A")
+    line_id = attr.ib(type=str, default="L001")
+    secondary_host = attr.ib(type=str, default="")
+    secondary_port = attr.ib(type=int, default=50001)
+    connection_mode = attr.ib(type=str, default="on_demand")
+    heartbeat_interval = attr.ib(type=int, default=300)
+    retry_count = attr.ib(type=int, default=3)
+    retry_delay = attr.ib(type=int, default=5)
+    timeout = attr.ib(type=int, default=30)
+    event_filter = attr.ib(type=list, default=[])
+    area_filter = attr.ib(type=list, default=[])
+
+
+@attr.s(slots=True, frozen=True)
 class MasterConfig:
     """Master storage Entry."""
 
@@ -83,6 +106,7 @@ class Config:
     ignore_blocking_sensors_after_trigger = attr.ib(type=bool, default=False)
     master = attr.ib(type=MasterConfig, default=MasterConfig())
     mqtt = attr.ib(type=MqttConfig, default=MqttConfig())
+    sia = attr.ib(type=SiaConfig, default=SiaConfig())
 
 
 @attr.s(slots=True, frozen=True)

--- a/custom_components/alarmo/websockets.py
+++ b/custom_components/alarmo/websockets.py
@@ -135,6 +135,25 @@ class AlarmoConfigView(HomeAssistantView):
                 vol.Optional(const.ATTR_MASTER): vol.Schema({
                     vol.Required(const.ATTR_ENABLED): cv.boolean,
                     vol.Optional(ATTR_NAME): cv.string,
+                }),
+                vol.Optional(const.ATTR_SIA): vol.Schema({
+                    vol.Required(const.CONF_SIA_ENABLED): cv.boolean,
+                    vol.Optional(const.CONF_SIA_HOST): cv.string,
+                    vol.Optional(const.CONF_SIA_PORT): cv.port,
+                    vol.Optional(const.CONF_SIA_PROTOCOL): vol.In(const.SIA_PROTOCOLS),
+                    vol.Optional(const.CONF_SIA_ACCOUNT): cv.string,
+                    vol.Optional(const.CONF_SIA_ENCRYPTION_KEY): cv.string,
+                    vol.Optional(const.CONF_SIA_RECEIVER_ID): cv.string,
+                    vol.Optional(const.CONF_SIA_LINE_ID): cv.string,
+                    vol.Optional(const.CONF_SIA_SECONDARY_HOST): cv.string,
+                    vol.Optional(const.CONF_SIA_SECONDARY_PORT): cv.port,
+                    vol.Optional(const.CONF_SIA_CONNECTION_MODE): vol.In(const.SIA_CONNECTION_MODES),
+                    vol.Optional(const.CONF_SIA_HEARTBEAT_INTERVAL): cv.positive_int,
+                    vol.Optional(const.CONF_SIA_RETRY_COUNT): cv.positive_int,
+                    vol.Optional(const.CONF_SIA_RETRY_DELAY): cv.positive_int,
+                    vol.Optional(const.CONF_SIA_TIMEOUT): cv.positive_int,
+                    vol.Optional(const.CONF_SIA_EVENT_FILTER): vol.All(cv.ensure_list, [cv.string]),
+                    vol.Optional(const.CONF_SIA_AREA_FILTER): vol.All(cv.ensure_list, [cv.string]),
                 })
             }
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ requires-python = ">=3.13.2"
 dependencies = [
     "homeassistant>=2025.5.0",
     "setuptools>=80.9.0",
+    "cryptography>=3.4.8",
+    "crcmod>=1.7",
 ]
 
 [dependency-groups]

--- a/tests/test_sia.py
+++ b/tests/test_sia.py
@@ -1,0 +1,314 @@
+"""Test SIA integration functionality."""
+
+from typing import Any
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+from tests.factories import AreaFactory, SensorFactory
+from tests.helpers import (
+    advance_time,
+    assert_alarm_state,
+    cleanup_timers,
+    patch_alarmo_integration_dependencies,
+    setup_alarmo_entry,
+)
+
+from custom_components.alarmo.const import (
+    DOMAIN,
+    EVENT_ARM,
+    EVENT_DISARM,
+    EVENT_TRIGGER,
+    ATTR_SIA,
+)
+from custom_components.alarmo.sia import SIAHandler
+
+ALARM_ENTITY = "alarm_control_panel.test_area_1"
+DOOR_SENSOR = "binary_sensor.front_door"
+
+
+def get_sia_config() -> dict:
+    """Get SIA configuration for testing."""
+    return {
+        "enabled": True,
+        "host": "192.168.1.100",
+        "port": 50001,
+        "protocol": "TCP",
+        "account": "1234",
+        "receiver_id": "R000A",
+        "line_id": "L001",
+        "encryption_key": "",
+        "secondary_host": "",
+        "secondary_port": 50001,
+        "connection_mode": "on_demand",
+        "heartbeat_interval": 300,
+        "retry_count": 3,
+        "retry_delay": 5,
+        "timeout": 30,
+        "event_filter": [],
+        "area_filter": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_sia_handler_initialization(hass: Any, enable_custom_integrations: Any) -> None:
+    """Test SIA handler initialization."""
+    area = AreaFactory.create_area(area_id="area_1", name="Test Area 1")
+    sensors = [
+        SensorFactory.create_sensor(
+            entity_id=DOOR_SENSOR,
+            name="Front Door",
+            area="area_1",
+            modes=["armed_away", "armed_home"],
+        )
+    ]
+
+    storage, entry = setup_alarmo_entry(
+        hass, areas=[area], sensors=sensors, entry_id="test_sia_init"
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Check that SIA handler was created
+        assert "sia_handler" in hass.data[DOMAIN]
+        sia_handler = hass.data[DOMAIN]["sia_handler"]
+        assert isinstance(sia_handler, SIAHandler)
+
+        await cleanup_timers(hass)
+
+
+@pytest.mark.asyncio
+async def test_sia_message_construction(hass: Any, enable_custom_integrations: Any) -> None:
+    """Test SIA message construction."""
+    area = AreaFactory.create_area(area_id="area_1", name="Test Area 1")
+    sensors = [
+        SensorFactory.create_sensor(
+            entity_id=DOOR_SENSOR,
+            name="Front Door",
+            area="area_1",
+            modes=["armed_away", "armed_home"],
+        )
+    ]
+
+    storage, entry = setup_alarmo_entry(
+        hass, areas=[area], sensors=sensors, entry_id="test_sia_message"
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        # Add SIA configuration to storage
+        storage["config"][ATTR_SIA] = get_sia_config()
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        sia_handler = hass.data[DOMAIN]["sia_handler"]
+
+        # Test event to SIA code mapping
+        code, description = sia_handler._event_to_sia_code(EVENT_ARM, "area_1", {"arm_mode": "armed_away"})
+        assert code == "CL"
+        assert "Armed Away" in description
+
+        code, description = sia_handler._event_to_sia_code(EVENT_DISARM, "area_1", {})
+        assert code == "OP"
+        assert "Disarmed" in description
+
+        code, description = sia_handler._event_to_sia_code(
+            EVENT_TRIGGER, "area_1", {"sensor_entity_id": DOOR_SENSOR}
+        )
+        assert code == "BA"  # Burglary Alarm
+        assert "Front Door" in description
+
+        # Test SIA message construction
+        message = sia_handler._build_sia_message("CL", "Armed Away - Test Area 1", "area_1")
+        assert '"SIA-DCS"' in message
+        assert "#1234|" in message  # Account number
+        assert "ri001CL" in message  # Area 1 and Close code
+        assert "R000A" in message  # Receiver ID
+        assert "L001" in message  # Line ID
+
+        await cleanup_timers(hass)
+
+
+@pytest.mark.asyncio
+async def test_sia_event_transmission(hass: Any, enable_custom_integrations: Any) -> None:
+    """Test SIA event transmission."""
+    area = AreaFactory.create_area(area_id="area_1", name="Test Area 1")
+    sensors = [
+        SensorFactory.create_sensor(
+            entity_id=DOOR_SENSOR,
+            name="Front Door",
+            area="area_1",
+            modes=["armed_away", "armed_home"],
+        )
+    ]
+
+    storage, entry = setup_alarmo_entry(
+        hass, areas=[area], sensors=sensors, entry_id="test_sia_transmission"
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        # Add SIA configuration to storage
+        storage["config"][ATTR_SIA] = get_sia_config()
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        sia_handler = hass.data[DOMAIN]["sia_handler"]
+
+        # Mock the network transmission
+        with patch.object(sia_handler, '_async_send_tcp', new_callable=AsyncMock) as mock_send:
+            # Force config update to load SIA settings
+            sia_handler._config = {ATTR_SIA: get_sia_config()}
+
+            # Trigger alarm arm event
+            await hass.services.async_call(
+                "alarmo", "arm", {"entity_id": ALARM_ENTITY, "mode": "away"}, blocking=True
+            )
+            await hass.async_block_till_done()
+
+            # Allow some time for async SIA transmission
+            await advance_time(hass, 2)
+
+            # Check that SIA message was sent
+            assert mock_send.called
+            args = mock_send.call_args[0]
+            host, port, message, timeout = args
+            assert host == "192.168.1.100"
+            assert port == 50001
+            assert '"SIA-DCS"' in message
+            assert "CL" in message  # Close/Arm code
+
+        await cleanup_timers(hass)
+
+
+@pytest.mark.asyncio
+async def test_sia_trigger_event_with_sensor_types(hass: Any, enable_custom_integrations: Any) -> None:
+    """Test SIA transmission for different sensor types."""
+    area = AreaFactory.create_area(area_id="area_1", name="Test Area 1")
+    sensors = [
+        SensorFactory.create_sensor(
+            entity_id="binary_sensor.smoke_detector",
+            name="Smoke Detector",
+            area="area_1",
+            modes=["armed_away", "armed_home"],
+            always_on=True,
+        )
+    ]
+
+    storage, entry = setup_alarmo_entry(
+        hass, areas=[area], sensors=sensors, entry_id="test_sia_sensor_types"
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        # Add SIA configuration to storage
+        storage["config"][ATTR_SIA] = get_sia_config()
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Set initial states
+        hass.states.async_set(ALARM_ENTITY, "disarmed")
+        hass.states.async_set("binary_sensor.smoke_detector", "off")
+        await hass.async_block_till_done()
+
+        sia_handler = hass.data[DOMAIN]["sia_handler"]
+
+        # Mock the entity state to include device_class
+        mock_state = MagicMock()
+        mock_state.attributes = {"device_class": "smoke", "friendly_name": "Smoke Detector"}
+
+        with patch.object(hass.states, 'get', return_value=mock_state):
+            with patch.object(sia_handler, '_async_send_tcp', new_callable=AsyncMock) as mock_send:
+                # Force config update to load SIA settings
+                sia_handler._config = {ATTR_SIA: get_sia_config()}
+
+                # Trigger smoke detector
+                hass.states.async_set("binary_sensor.smoke_detector", "on")
+                await hass.async_block_till_done()
+                await advance_time(hass, 2)
+
+                # Check that fire alarm (FA) code was sent
+                assert mock_send.called
+                args = mock_send.call_args[0]
+                message = args[2]  # message is the third argument
+                assert "FA" in message  # Fire Alarm code
+
+        await cleanup_timers(hass)
+
+
+@pytest.mark.asyncio
+async def test_sia_encryption(hass: Any, enable_custom_integrations: Any) -> None:
+    """Test SIA message encryption."""
+    area = AreaFactory.create_area(area_id="area_1", name="Test Area 1")
+    sensors = []
+
+    storage, entry = setup_alarmo_entry(
+        hass, areas=[area], sensors=sensors, entry_id="test_sia_encryption"
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        # Set SIA configuration with encryption key
+        sia_config = get_sia_config()
+        sia_config["encryption_key"] = "testkey1234567890"
+
+        # Add SIA configuration to storage
+        storage["config"][ATTR_SIA] = sia_config
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        sia_handler = hass.data[DOMAIN]["sia_handler"]
+
+        # Test encryption
+        original_message = "#1234|Nri001CL[Armed Away]_14:25:36,10-28-2025"
+        encrypted_message = sia_handler._encrypt_message(original_message, "testkey1234567890")
+
+        # Encrypted message should be different and in hex format
+        assert encrypted_message != original_message
+        assert len(encrypted_message) > 0
+        # Should be hex encoded (uppercase)
+        assert all(c in "0123456789ABCDEF" for c in encrypted_message)
+
+        # Test SIA message with encryption flag
+        message = sia_handler._build_sia_message("CL", "Armed Away - Test Area 1", "area_1")
+        # Should contain encryption flag
+        assert '"*SIA-DCS"' in message
+
+        await cleanup_timers(hass)
+
+
+@pytest.mark.asyncio
+async def test_sia_sequence_number_management(hass: Any, enable_custom_integrations: Any) -> None:
+    """Test SIA sequence number management and persistence."""
+    area = AreaFactory.create_area(area_id="area_1", name="Test Area 1")
+    sensors = []
+
+    storage, entry = setup_alarmo_entry(
+        hass, areas=[area], sensors=sensors, entry_id="test_sia_sequence"
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        sia_handler = hass.data[DOMAIN]["sia_handler"]
+
+        # Test sequence number generation
+        seq1 = sia_handler._get_next_sequence()
+        seq2 = sia_handler._get_next_sequence()
+        seq3 = sia_handler._get_next_sequence()
+
+        assert seq1 == "0001"
+        assert seq2 == "0002"
+        assert seq3 == "0003"
+
+        # Test sequence number wraparound
+        sia_handler._sequence_number = 9999
+        seq_wrap = sia_handler._get_next_sequence()
+        seq_after_wrap = sia_handler._get_next_sequence()
+
+        assert seq_wrap == "9999"
+        assert seq_after_wrap == "0001"
+
+        await cleanup_timers(hass)


### PR DESCRIPTION
The goal of this PR is to add support to Alarmo to send events/SIA codes to a defined remote "server".  