### PR TITLE
Fix alarm stuck unavailable after restart

### DIFF
--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -15,6 +15,8 @@ from homeassistant.util import slugify
 from homeassistant.const import (
     ATTR_NAME,
     ATTR_CODE_FORMAT,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.helpers import entity_platform
 from homeassistant.exceptions import HomeAssistantError
@@ -768,7 +770,7 @@ class AlarmoAreaEntity(AlarmoBaseEntity):
 
         # restore previous state
         state = await self.async_get_last_state()
-        if state:
+        if state and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             initial_state = state.state
             _LOGGER.debug(
                 "Initial state for %s is %s",


### PR DESCRIPTION
If the last saved state for an alarmo panel is is `unavailable` or `unknown` (e.g. after a Z-Wave stick swap or integration hiccup in my case), the restore logic restores it and the alarm gets stuck permanently. Restarts don't help since the bad state just gets re-saved and re-restored each boot.
                                                                                                                                                    
Small fix: treat unavailable/unknown the same as no previous state, so it falls back to disarmed. This resolves the issue for me.

Found https://github.com/nielsfaber/alarmo/issues/1324 which seems like the same issue.

This may be related too:

https://github.com/nielsfaber/alarmo/issues/1279
