### PR TITLE
Issue/1394/refactor_auth

### DIFF
--- a/custom_components/alarmo/__init__.py
+++ b/custom_components/alarmo/__init__.py
@@ -3,7 +3,6 @@
 import re
 import base64
 import logging
-import concurrent.futures
 
 import bcrypt
 from homeassistant.core import (
@@ -49,8 +48,6 @@ from .automations import AutomationHandler
 
 _LOGGER = logging.getLogger(__name__)
 
-# Max number of threads to start when checking user codes.
-MAX_WORKERS = 4
 # Number of rounds of hashing when computing user hashes.
 BCRYPT_NUM_ROUNDS = 10
 
@@ -272,12 +269,14 @@ class AlarmoCoordinator(DataUpdateCoordinator):
 
         async_dispatcher_send(self.hass, "alarmo_sensors_updated")
 
-    def _validate_user_code(self, user_id: str, data: dict):
-        user_with_code = self.async_authenticate_user(data[ATTR_CODE])
+    async def _validate_user_code(self, user_id: str, data: dict):
+        user_with_code = await self.async_authenticate_user(data[ATTR_CODE])
         if user_id:
             if const.ATTR_OLD_CODE not in data:
                 return "No code provided"
-            if not self.async_authenticate_user(data[const.ATTR_OLD_CODE], user_id):
+            if not await self.async_authenticate_user(
+                data[const.ATTR_OLD_CODE], user_id
+            ):
                 return "Wrong code provided"
             if user_with_code and user_with_code[const.ATTR_USER_ID] != user_id:
                 return "User with same code already exists"
@@ -296,7 +295,9 @@ class AlarmoCoordinator(DataUpdateCoordinator):
                 return "User with same name already exists"
         return
 
-    def async_update_user_config(self, user_id: str | None = None, data: dict = {}):
+    async def async_update_user_config(
+        self, user_id: str | None = None, data: dict = {}
+    ):
         """Update user configuration."""
         if const.ATTR_REMOVE in data:
             self.store.async_delete_user(user_id)
@@ -308,7 +309,7 @@ class AlarmoCoordinator(DataUpdateCoordinator):
                 _LOGGER.error(err)
                 return err
         if ATTR_CODE in data:
-            err = self._validate_user_code(user_id, data)
+            err = await self._validate_user_code(user_id, data)
             if err:
                 _LOGGER.error(err)
                 return err
@@ -318,12 +319,17 @@ class AlarmoCoordinator(DataUpdateCoordinator):
                 "number" if data[ATTR_CODE].isdigit() else "text"
             )
             data[const.ATTR_CODE_LENGTH] = len(data[ATTR_CODE])
-            hashed = bcrypt.hashpw(
-                data[ATTR_CODE].encode("utf-8"),
-                bcrypt.gensalt(rounds=BCRYPT_NUM_ROUNDS),
+
+            def _hash_code(code):
+                hashed = bcrypt.hashpw(
+                    code.encode("utf-8"),
+                    bcrypt.gensalt(rounds=BCRYPT_NUM_ROUNDS),
+                )
+                return base64.b64encode(hashed).decode()
+
+            data[ATTR_CODE] = await self.hass.async_add_executor_job(
+                _hash_code, data[ATTR_CODE]
             )
-            hashed = base64.b64encode(hashed)
-            data[ATTR_CODE] = hashed.decode()
 
         if not user_id:
             self.store.async_create_user(data)
@@ -334,32 +340,42 @@ class AlarmoCoordinator(DataUpdateCoordinator):
             self.store.async_update_user(user_id, data)
             return
 
-    def async_authenticate_user(self, code: str, user_id: str | None = None):
-        """Authenticate a user by code."""
+    async def async_authenticate_user(self, code, user_id=None):
+        """Run user authentication in the executor.
 
-        def check_user_code(user, code):
-            """Returns the supplied user object if the code matches, None otherwise."""
-            if not user[const.ATTR_ENABLED]:
-                return
-            elif not user[ATTR_CODE] and not code:
-                return user
-            elif user[ATTR_CODE]:
-                hash = base64.b64decode(user[ATTR_CODE])
-                if bcrypt.checkpw(code.encode("utf-8"), hash):
+        This wrapper ensures that the blocking bcrypt-based authentication
+        is executed outside of the event loop, making it safe to call
+        from async context.
+        """
+
+        def _authenticate_user_sync():
+            """Perform user authentication using blocking bcrypt operations."""
+
+            def check_user_code(user, code):
+                """Returns None or the supplied user object if the code matches."""
+                if not user[const.ATTR_ENABLED]:
+                    return None
+                elif not user[ATTR_CODE] and not code:
                     return user
+                elif user[ATTR_CODE]:
+                    try:
+                        hash = base64.b64decode(user[ATTR_CODE])
+                    except Exception:
+                        return None
+                    if bcrypt.checkpw((code or "").encode("utf-8"), hash):
+                        return user
 
-        if user_id:
-            return check_user_code(self.store.async_get_user(user_id), code)
+            if user_id:
+                return check_user_code(self.store.async_get_user(user_id), code)
 
-        users = self.store.async_get_users()
-        with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
-            futures = [
-                executor.submit(check_user_code, user, code) for user in users.values()
-            ]
-            for future in concurrent.futures.as_completed(futures):
-                if future.result():
-                    executor.shutdown(wait=False, cancel_futures=True)
-                    return future.result()
+            users = self.store.async_get_users()
+            for user in users.values():
+                result = check_user_code(user, code)
+                if result:
+                    return result
+            return None
+
+        return await self.hass.async_add_executor_job(_authenticate_user_sync)
 
     def async_update_automation_config(
         self,
@@ -421,21 +437,21 @@ class AlarmoCoordinator(DataUpdateCoordinator):
 
             if action == const.EVENT_ACTION_FORCE_ARM:
                 _LOGGER.info("Received request for force arming")
-                alarm_entity.async_handle_arm_request(
+                await alarm_entity.async_handle_arm_request(
                     arm_mode, skip_code=True, bypass_open_sensors=True
                 )
             elif action == const.EVENT_ACTION_RETRY_ARM:
                 _LOGGER.info("Received request for retry arming")
-                alarm_entity.async_handle_arm_request(arm_mode, skip_code=True)
+                await alarm_entity.async_handle_arm_request(arm_mode, skip_code=True)
             elif action == const.EVENT_ACTION_DISARM:
                 _LOGGER.info("Received request for disarming")
-                alarm_entity.alarm_disarm(None, skip_code=True)
+                await alarm_entity.async_alarm_disarm(None, skip_code=True)
             else:
                 _LOGGER.info(
                     "Received request for arming with mode %s",
                     arm_mode,
                 )
-                alarm_entity.async_handle_arm_request(arm_mode, skip_code=True)
+                await alarm_entity.async_handle_arm_request(arm_mode, skip_code=True)
 
         self._subscriptions.append(
             self.hass.bus.async_listen(const.PUSH_EVENT, async_handle_push_event)

--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -320,8 +320,13 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             "last_triggered": self.last_triggered,
         }
 
-    def _is_code_required(self, to_state):
-        """Check if code validation is required based on config."""
+    async def _validate_code(self, code, to_state):  # noqa PLR0911
+        """Validate code and user permissions for a requested state change.
+
+        Returns a (success, error_event) tuple. When success is True,
+        error_event is None.
+        """
+        # check bypass rules
         if (
             to_state == AlarmControlPanelState.DISARMED
             and not self._config[const.ATTR_CODE_DISARM_REQUIRED]
@@ -329,7 +334,8 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             _LOGGER.debug(
                 "Code is not required for disarming, bypassing code validation."
             )
-            return False
+            self._changed_by = None
+            return True, None
 
         if (
             to_state != AlarmControlPanelState.DISARMED
@@ -337,7 +343,8 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             and not self._config[ATTR_CODE_ARM_REQUIRED]
         ):
             _LOGGER.debug("Code is not required for arming, bypassing code validation.")
-            return False
+            self._changed_by = None
+            return True, None
 
         if (
             AlarmControlPanelState.DISARMED not in {to_state, self._state}
@@ -346,38 +353,36 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             _LOGGER.debug(
                 "Code is not required for mode change, bypassing code validation."
             )
-            return False
+            self._changed_by = None
+            return True, None
 
-        return True
-
-    def _is_user_allowed_for_area(self, user):
-        """Check if user has permissions for the area of this entity."""
+        if not code or len(code) < 1:
+            _LOGGER.debug("No code provided, but code is required. Rejecting command.")
+            return False, const.EVENT_NO_CODE_PROVIDED
+        # resolve user
+        user = await self.hass.data[const.DOMAIN][
+            "coordinator"
+        ].async_authenticate_user(code)
         if not user:
-            return False
+            return False, const.EVENT_INVALID_CODE_PROVIDED
 
+        # area permission check
         allowed_areas = user.get(const.ATTR_AREA_LIMIT)
-
-        if not allowed_areas:
-            return True  # global access
-
-        target_areas = (
-            [self.area_id]
-            if self.area_id
-            else list(self.hass.data[const.DOMAIN]["areas"].keys())
-        )
-
-        if not all(area in allowed_areas for area in target_areas):
-            # user is not allowed to operate this area
-            _LOGGER.debug(
-                "User %s has no permission to arm/disarm this area.",
-                user[ATTR_NAME],
+        if allowed_areas:
+            target_areas = (
+                [self.area_id]
+                if self.area_id
+                else list(self.hass.data[const.DOMAIN]["areas"].keys())
             )
-            return False
-        else:
-            return True
+            if not all(area in allowed_areas for area in target_areas):
+                # user is not allowed to operate this area
+                _LOGGER.debug(
+                    "User %s has no permission to arm/disarm this area.",
+                    user[ATTR_NAME],
+                )
+                return False, const.EVENT_INVALID_CODE_PROVIDED
 
-    def _is_user_allowed_for_action(self, user, to_state):
-        """Check if user has permissions for the specific action (arm/disarm)."""
+        # action permission check
         if to_state == AlarmControlPanelState.DISARMED:
             if not user.get("can_disarm", False):
                 # user is not allowed to disarm the alarm
@@ -385,53 +390,16 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
                     "User %s has no permission to disarm the alarm.",
                     user.get(ATTR_NAME, "unknown user"),
                 )
-                return False
-            else:
-                return True
-
-        if to_state in const.ARM_MODES:
+                return False, const.EVENT_INVALID_CODE_PROVIDED
+        elif to_state in const.ARM_MODES:
             if not user.get("can_arm", False):
                 # user is not allowed to arm the alarm
                 _LOGGER.debug(
                     "User %s has no permission to arm the alarm.",
                     user.get(ATTR_NAME, "unknown user"),
                 )
-                return False
-            else:
-                return True
-
-        return False
-
-    async def _resolve_user(self, code):
-        """Resolve user based on provided code."""
-        if not code or len(code) < 1:
-            _LOGGER.debug("No code provided, cannot resolve user.")
-            return None
-        # delegate user resolution to coordinator through job executor
-        return await self.hass.data[const.DOMAIN][
-            "coordinator"
-        ].async_authenticate_user(code)
-
-    async def _authorize_state_transition(self, code, to_state):
-        """Main authorization pipeline."""
-        # check bypass rules
-        if not self._is_code_required(to_state):
-            self._changed_by = None
-            return True, None
-
-        if not code or len(code) < 1:
-            return False, const.EVENT_NO_CODE_PROVIDED
-        # resolve user
-        user = await self._resolve_user(code)
-        if not user:
-            return False, const.EVENT_INVALID_CODE_PROVIDED
-
-        # area permission check
-        if not self._is_user_allowed_for_area(user):
-            return False, const.EVENT_INVALID_CODE_PROVIDED
-
-        # action permission check
-        if not self._is_user_allowed_for_action(user, to_state):
+                return False, const.EVENT_INVALID_CODE_PROVIDED
+        else:
             return False, const.EVENT_INVALID_CODE_PROVIDED
 
         # success
@@ -474,7 +442,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             )
             return
         if not skip_code:
-            (res, info) = await self._authorize_state_transition(
+            (res, info) = await self._validate_code(
                 code, AlarmControlPanelState.DISARMED
             )
         else:
@@ -593,7 +561,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             return False
 
         if not skip_code:
-            (res, info) = await self._authorize_state_transition(code, arm_mode)
+            (res, info) = await self._validate_code(code, arm_mode)
             if not res:
                 dispatcher_send(
                     self.hass,
@@ -1477,7 +1445,7 @@ class AlarmoMasterEntity(AlarmoBaseEntity):
 
         # when skip_code is False, validate the code before disarming
         if not skip_code:
-            (res, info) = await self._authorize_state_transition(
+            (res, info) = await self._validate_code(
                 code, AlarmControlPanelState.DISARMED
             )
             if not res:

--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -320,67 +320,123 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             "last_triggered": self.last_triggered,
         }
 
-    async def _validate_code(self, code, to_state):  # noqa PLR0911
-        """Validate given code."""
+    def _is_code_required(self, to_state):
+        """Check if code validation is required based on config."""
         if (
             to_state == AlarmControlPanelState.DISARMED
             and not self._config[const.ATTR_CODE_DISARM_REQUIRED]
         ):
-            self._changed_by = None
-            return (True, None)
-        elif (
+            _LOGGER.debug(
+                "Code is not required for disarming, bypassing code validation."
+            )
+            return False
+
+        if (
             to_state != AlarmControlPanelState.DISARMED
             and self._state == AlarmControlPanelState.DISARMED
             and not self._config[ATTR_CODE_ARM_REQUIRED]
         ):
-            self._changed_by = None
-            return (True, None)
-        elif (
+            _LOGGER.debug("Code is not required for arming, bypassing code validation.")
+            return False
+
+        if (
             AlarmControlPanelState.DISARMED not in {to_state, self._state}
             and not self._config[const.ATTR_CODE_MODE_CHANGE_REQUIRED]
         ):
-            self._changed_by = None
-            return (True, None)
-        elif not code or len(code) < 1:
-            return (False, const.EVENT_NO_CODE_PROVIDED)
-
-        res = await self.hass.data[const.DOMAIN]["coordinator"].async_authenticate_user(
-            code
-        )
-        if not res:
-            # wrong code was entered
-            return (False, const.EVENT_INVALID_CODE_PROVIDED)
-        elif res[const.ATTR_AREA_LIMIT] and not all(
-            area in res[const.ATTR_AREA_LIMIT]
-            for area in (
-                [self.area_id]
-                if self.area_id
-                else list(self.hass.data[const.DOMAIN]["areas"].keys())
+            _LOGGER.debug(
+                "Code is not required for mode change, bypassing code validation."
             )
-        ):
+            return False
+
+        return True
+
+    def _is_user_allowed_for_area(self, user):
+        """Check if user has permissions for the area of this entity."""
+        if not user:
+            return False
+
+        allowed_areas = user.get(const.ATTR_AREA_LIMIT)
+
+        if not allowed_areas:
+            return True  # global access
+
+        target_areas = (
+            [self.area_id]
+            if self.area_id
+            else list(self.hass.data[const.DOMAIN]["areas"].keys())
+        )
+
+        if not all(area in allowed_areas for area in target_areas):
             # user is not allowed to operate this area
             _LOGGER.debug(
                 "User %s has no permission to arm/disarm this area.",
-                res[ATTR_NAME],
+                user[ATTR_NAME],
             )
-            return (False, const.EVENT_INVALID_CODE_PROVIDED)
-        elif to_state == AlarmControlPanelState.DISARMED and not res["can_disarm"]:
-            # user is not allowed to disarm the alarm
-            _LOGGER.debug(
-                "User %s has no permission to disarm the alarm.",
-                res[ATTR_NAME],
-            )
-            return (False, const.EVENT_INVALID_CODE_PROVIDED)
-        elif to_state in const.ARM_MODES and not res["can_arm"]:
-            # user is not allowed to arm the alarm
-            _LOGGER.debug(
-                "User %s has no permission to arm the alarm.",
-                res[ATTR_NAME],
-            )
-            return (False, const.EVENT_INVALID_CODE_PROVIDED)
+            return False
         else:
-            self._changed_by = res[ATTR_NAME]
-            return (True, res)
+            return True
+
+    def _is_user_allowed_for_action(self, user, to_state):
+        """Check if user has permissions for the specific action (arm/disarm)."""
+        if to_state == AlarmControlPanelState.DISARMED:
+            if not user.get("can_disarm", False):
+                # user is not allowed to disarm the alarm
+                _LOGGER.debug(
+                    "User %s has no permission to disarm the alarm.",
+                    user.get(ATTR_NAME, "unknown user"),
+                )
+                return False
+            else:
+                return True
+
+        if to_state in const.ARM_MODES:
+            if not user.get("can_arm", False):
+                # user is not allowed to arm the alarm
+                _LOGGER.debug(
+                    "User %s has no permission to arm the alarm.",
+                    user.get(ATTR_NAME, "unknown user"),
+                )
+                return False
+            else:
+                return True
+
+        return False
+
+    async def _resolve_user(self, code):
+        """Resolve user based on provided code."""
+        if not code or len(code) < 1:
+            _LOGGER.debug("No code provided, cannot resolve user.")
+            return None
+        # delegate user resolution to coordinator through job executor
+        return await self.hass.data[const.DOMAIN][
+            "coordinator"
+        ].async_authenticate_user(code)
+
+    async def _authorize_state_transition(self, code, to_state):
+        """Main authorization pipeline."""
+        # check bypass rules
+        if not self._is_code_required(to_state):
+            self._changed_by = None
+            return True, None
+
+        if not code or len(code) < 1:
+            return False, const.EVENT_NO_CODE_PROVIDED
+        # resolve user
+        user = await self._resolve_user(code)
+        if not user:
+            return False, const.EVENT_INVALID_CODE_PROVIDED
+
+        # area permission check
+        if not self._is_user_allowed_for_area(user):
+            return False, const.EVENT_INVALID_CODE_PROVIDED
+
+        # action permission check
+        if not self._is_user_allowed_for_action(user, to_state):
+            return False, const.EVENT_INVALID_CODE_PROVIDED
+
+        # success
+        self._changed_by = user[ATTR_NAME]
+        return True, None
 
     async def async_service_disarm_handler(self, code, context_id=None):
         """Handle external disarm request from alarmo.disarm service."""
@@ -417,7 +473,13 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
                 },
             )
             return
-        (res, info) = await self._validate_code(code, AlarmControlPanelState.DISARMED)
+        if not skip_code:
+            (res, info) = await self._authorize_state_transition(
+                code, AlarmControlPanelState.DISARMED
+            )
+        else:
+            res, info = (True, None)
+
         if not res and not skip_code:
             dispatcher_send(
                 self.hass,
@@ -531,7 +593,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             return False
 
         if not skip_code:
-            (res, info) = await self._validate_code(code, arm_mode)
+            (res, info) = await self._authorize_state_transition(code, arm_mode)
             if not res:
                 dispatcher_send(
                     self.hass,
@@ -1413,11 +1475,36 @@ class AlarmoMasterEntity(AlarmoBaseEntity):
         skip_code = kwargs.get("skip_code", False)
         context_id = kwargs.get("context_id", None)
 
-        res = await super().async_alarm_disarm(code=code, skip_code=skip_code)
-        if res:
+        # when skip_code is False, validate the code before disarming
+        if not skip_code:
+            (res, info) = await self._authorize_state_transition(
+                code, AlarmControlPanelState.DISARMED
+            )
+            if not res:
+                dispatcher_send(
+                    self.hass,
+                    "alarmo_event",
+                    info,
+                    self.area_id,
+                    {
+                        const.ATTR_CONTEXT_ID: context_id,
+                        "command": const.COMMAND_DISARM,
+                    },
+                )
+                _LOGGER.warning("Wrong code provided.")
+                return False
+        if skip_code or res:
+            # code has been validated or skip_code is True, proceed with disarm
+            if not await super().async_alarm_disarm(
+                code=code, skip_code=True, context_id=context_id
+            ):
+                _LOGGER.error("Failed to disarm master alarm.")
+                return False
             for item in self.hass.data[const.DOMAIN]["areas"].values():
                 if item.state != AlarmControlPanelState.DISARMED:
-                    await item.async_alarm_disarm(code=code, skip_code=skip_code)
+                    await item.async_alarm_disarm(
+                        code=code, skip_code=True, context_id=context_id
+                    )
 
             dispatcher_send(
                 self.hass,
@@ -1426,7 +1513,8 @@ class AlarmoMasterEntity(AlarmoBaseEntity):
                 self.area_id,
                 {const.ATTR_CONTEXT_ID: context_id},
             )
-        return res
+            return True
+        return False
 
     def async_arm(self, arm_mode, **kwargs):
         """Arm the alarm or switch between arm modes."""

--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -320,7 +320,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             "last_triggered": self.last_triggered,
         }
 
-    def _validate_code(self, code, to_state):  # noqa PLR0911
+    async def _validate_code(self, code, to_state):  # noqa PLR0911
         """Validate given code."""
         if (
             to_state == AlarmControlPanelState.DISARMED
@@ -344,7 +344,9 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
         elif not code or len(code) < 1:
             return (False, const.EVENT_NO_CODE_PROVIDED)
 
-        res = self.hass.data[const.DOMAIN]["coordinator"].async_authenticate_user(code)
+        res = await self.hass.data[const.DOMAIN]["coordinator"].async_authenticate_user(
+            code
+        )
         if not res:
             # wrong code was entered
             return (False, const.EVENT_INVALID_CODE_PROVIDED)
@@ -380,15 +382,13 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             self._changed_by = res[ATTR_NAME]
             return (True, res)
 
-    @callback
-    def async_service_disarm_handler(self, code, context_id=None):
+    async def async_service_disarm_handler(self, code, context_id=None):
         """Handle external disarm request from alarmo.disarm service."""
         _LOGGER.debug("Service alarmo.disarm was called")
 
-        self.alarm_disarm(code=code, context_id=context_id)
+        await self.async_alarm_disarm(code=code, context_id=context_id)
 
-    @callback
-    def alarm_disarm(self, code, **kwargs):
+    async def async_alarm_disarm(self, code, **kwargs):
         """Send disarm command."""
         _LOGGER.debug("alarm_disarm")
         skip_code = kwargs.get("skip_code", False)
@@ -417,7 +417,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
                 },
             )
             return
-        (res, info) = self._validate_code(code, AlarmControlPanelState.DISARMED)
+        (res, info) = await self._validate_code(code, AlarmControlPanelState.DISARMED)
         if not res and not skip_code:
             dispatcher_send(
                 self.hass,
@@ -457,14 +457,20 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             return True
 
     @callback
-    def async_service_arm_handler(self, code, mode, skip_delay, force, context_id=None):
+    def alarm_disarm(self, code=None, **kwargs):
+        """Send disarm command (sync wrapper)."""
+        self.hass.async_create_task(self.async_alarm_disarm(code=code, **kwargs))
+
+    async def async_service_arm_handler(
+        self, code, mode, skip_delay, force, context_id=None
+    ):
         """Handle external arm request from alarmo.arm service."""
         _LOGGER.debug("Service alarmo.arm was called")
 
         if mode in const.ARM_MODE_TO_STATE:
             mode = const.ARM_MODE_TO_STATE[mode]
 
-        self.async_handle_arm_request(
+        await self.async_handle_arm_request(
             mode,
             code=code,
             skip_delay=skip_delay,
@@ -472,8 +478,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             context_id=context_id,
         )
 
-    @callback
-    def async_handle_arm_request(self, arm_mode, **kwargs):
+    async def async_handle_arm_request(self, arm_mode, **kwargs):
         """Check if conditions are met for starting arm procedure."""
         code = kwargs.get(const.CONF_CODE, "")
         skip_code = kwargs.get("skip_code", False)
@@ -526,7 +531,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             return False
 
         if not skip_code:
-            (res, info) = self._validate_code(code, arm_mode)
+            (res, info) = await self._validate_code(code, arm_mode)
             if not res:
                 dispatcher_send(
                     self.hass,
@@ -600,7 +605,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
     ):
         """Send arm away command."""
         _LOGGER.debug("alarm_arm_away")
-        self.async_handle_arm_request(
+        await self.async_handle_arm_request(
             AlarmControlPanelState.ARMED_AWAY,
             code=code,
             skip_code=skip_code,
@@ -613,7 +618,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
     ):
         """Send arm home command."""
         _LOGGER.debug("alarm_arm_home")
-        self.async_handle_arm_request(
+        await self.async_handle_arm_request(
             AlarmControlPanelState.ARMED_HOME,
             code=code,
             skip_code=skip_code,
@@ -626,7 +631,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
     ):
         """Send arm night command."""
         _LOGGER.debug("alarm_arm_night")
-        self.async_handle_arm_request(
+        await self.async_handle_arm_request(
             AlarmControlPanelState.ARMED_NIGHT,
             code=code,
             skip_code=skip_code,
@@ -639,7 +644,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
     ):
         """Send arm custom_bypass command."""
         _LOGGER.debug("alarm_arm_custom_bypass")
-        self.async_handle_arm_request(
+        await self.async_handle_arm_request(
             AlarmControlPanelState.ARMED_CUSTOM_BYPASS,
             code=code,
             skip_code=skip_code,
@@ -652,7 +657,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
     ):
         """Send arm vacation command."""
         _LOGGER.debug("alarm_arm_vacation")
-        self.async_handle_arm_request(
+        await self.async_handle_arm_request(
             AlarmControlPanelState.ARMED_VACATION,
             code=code,
             skip_code=skip_code,
@@ -1403,18 +1408,16 @@ class AlarmoMasterEntity(AlarmoBaseEntity):
                 self.hass, "alarmo_state_updated", None, old_state, new_state
             )
 
-    @callback
-    def alarm_disarm(self, code=None, **kwargs):
+    async def async_alarm_disarm(self, code=None, **kwargs):
         """Send disarm command."""
         skip_code = kwargs.get("skip_code", False)
         context_id = kwargs.get("context_id", None)
 
-        """Send disarm command."""
-        res = super().alarm_disarm(code=code, skip_code=skip_code)
+        res = await super().async_alarm_disarm(code=code, skip_code=skip_code)
         if res:
             for item in self.hass.data[const.DOMAIN]["areas"].values():
                 if item.state != AlarmControlPanelState.DISARMED:
-                    item.alarm_disarm(code=code, skip_code=skip_code)
+                    await item.async_alarm_disarm(code=code, skip_code=skip_code)
 
             dispatcher_send(
                 self.hass,
@@ -1423,6 +1426,7 @@ class AlarmoMasterEntity(AlarmoBaseEntity):
                 self.area_id,
                 {const.ATTR_CONTEXT_ID: context_id},
             )
+        return res
 
     def async_arm(self, arm_mode, **kwargs):
         """Arm the alarm or switch between arm modes."""

--- a/custom_components/alarmo/websockets.py
+++ b/custom_components/alarmo/websockets.py
@@ -284,7 +284,7 @@ class AlarmoUserView(HomeAssistantView):
         if const.ATTR_USER_ID in data:
             user_id = data[const.ATTR_USER_ID]
             del data[const.ATTR_USER_ID]
-        err = coordinator.async_update_user_config(user_id, data)
+        err = await coordinator.async_update_user_config(user_id, data)
         async_dispatcher_send(hass, "alarmo_update_frontend")
         return self.json({"success": not isinstance(err, str), "error": err})
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,6 +1,7 @@
 """Factories for creating test objects with defaults."""
 
 import copy
+import time
 import base64
 from typing import Any, ClassVar
 
@@ -456,6 +457,33 @@ class MockStorage:
     def async_get_users(self) -> dict[str, Any]:
         """Get all users."""
         return self.users
+
+    def async_get_user(self, user_id: str) -> dict[str, Any] | None:
+        """Get a user by ID."""
+        return self.users.get(user_id)
+
+    def async_create_user(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Create a new user."""
+        user_id = str(int(time.time()))
+        user = {"user_id": user_id, **data}
+        self.users[user_id] = user
+        return user
+
+    def async_delete_user(self, user_id: str) -> bool:
+        """Delete a user by ID."""
+        if user_id in self.users:
+            del self.users[user_id]
+            return True
+        return False
+
+    def async_update_user(
+        self, user_id: str, changes: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Update an existing user."""
+        if user_id not in self.users:
+            raise KeyError(f"User {user_id} not found in mock storage")
+        self.users[user_id].update(changes)
+        return self.users[user_id]
 
     def async_get_config(self) -> dict[str, Any]:
         """Get the config."""

--- a/tests/test_alarm_master.py
+++ b/tests/test_alarm_master.py
@@ -1,6 +1,7 @@
 """Test alarm master functionality with multiple areas."""
 
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -11,7 +12,8 @@ from tests.helpers import (
     setup_alarmo_entry,
     patch_alarmo_integration_dependencies,
 )
-from tests.factories import AreaFactory, SensorFactory
+from tests.factories import AreaFactory, UserFactory, SensorFactory
+from custom_components.alarmo import const
 
 
 @pytest.mark.asyncio
@@ -304,4 +306,184 @@ async def test_alarm_master_priority_states(
             blocking=True,
         )
         await hass.async_block_till_done()
+        assert_alarm_state(hass, "alarm_control_panel.master", "disarmed")
+
+
+@pytest.mark.asyncio
+async def test_alarm_master_disarm_denied_for_area_limited_user(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Master disarm should fail if user lacks permission for all areas."""
+    area1 = AreaFactory.create_area(
+        area_id="area_1",
+        name="Test Area 1 Limited",
+        modes=["armed_away"],
+        armed_away_enabled=True,
+        armed_away_exit_time=0,
+    )
+    area2 = AreaFactory.create_area(
+        area_id="area_2",
+        name="Test Area 2 Limited",
+        modes=["armed_away"],
+        armed_away_enabled=True,
+        armed_away_exit_time=0,
+    )
+
+    sensor1 = SensorFactory.create_door_sensor(
+        entity_id="binary_sensor.area_1_door", area="area_1"
+    )
+    sensor2 = SensorFactory.create_door_sensor(
+        entity_id="binary_sensor.area_2_door", area="area_2"
+    )
+
+    users = {
+        "admin_user": UserFactory.create_user(
+            user_id="admin_user",
+            name="Admin User",
+            code="1234",
+            can_arm=True,
+            can_disarm=True,
+        ),
+        "limited_user": UserFactory.create_user(
+            user_id="limited_user",
+            name="Limited User",
+            code="3456",
+            can_arm=True,
+            can_disarm=True,
+            area_limit="area_1",
+        ),
+    }
+
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=[area1, area2],
+        sensors=[sensor1, sensor2],
+        entry_id="test_master_disarm_limited",
+        users=users,
+        master_enabled=True,
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        hass.states.async_set("binary_sensor.area_1_door", "off")
+        hass.states.async_set("binary_sensor.area_2_door", "off")
+        await hass.async_block_till_done()
+
+        # Arm via master with admin user
+        await hass.services.async_call(
+            "alarm_control_panel",
+            "alarm_arm_away",
+            {"entity_id": "alarm_control_panel.master", "code": "1234"},
+            blocking=True,
+        )
+        await advance_time(hass, 1)
+
+        assert_alarm_state(
+            hass, "alarm_control_panel.test_area_1_limited", "armed_away"
+        )
+        assert_alarm_state(
+            hass, "alarm_control_panel.test_area_2_limited", "armed_away"
+        )
+        assert_alarm_state(hass, "alarm_control_panel.master", "armed_away")
+
+        # Attempt to disarm master with area-limited user
+        await hass.services.async_call(
+            "alarm_control_panel",
+            "alarm_disarm",
+            {"entity_id": "alarm_control_panel.master", "code": "3456"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        # Should remain armed since user cannot operate all areas
+        assert_alarm_state(
+            hass, "alarm_control_panel.test_area_1_limited", "armed_away"
+        )
+        assert_alarm_state(
+            hass, "alarm_control_panel.test_area_2_limited", "armed_away"
+        )
+        assert_alarm_state(hass, "alarm_control_panel.master", "armed_away")
+
+
+@pytest.mark.asyncio
+async def test_alarm_master_disarm_auth_resolved_once(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Master disarm resolves the user only once and reuses it for all areas."""
+    area1 = AreaFactory.create_area(
+        area_id="area_1",
+        name="Test Area 1 Auth",
+        modes=["armed_away"],
+        armed_away_enabled=True,
+        armed_away_exit_time=0,
+    )
+    area2 = AreaFactory.create_area(
+        area_id="area_2",
+        name="Test Area 2 Auth",
+        modes=["armed_away"],
+        armed_away_enabled=True,
+        armed_away_exit_time=0,
+    )
+
+    sensor1 = SensorFactory.create_door_sensor(
+        entity_id="binary_sensor.area_1_door", area="area_1"
+    )
+    sensor2 = SensorFactory.create_door_sensor(
+        entity_id="binary_sensor.area_2_door", area="area_2"
+    )
+
+    users = {
+        "admin_user": UserFactory.create_user(
+            user_id="admin_user",
+            name="Admin User",
+            code="1234",
+            can_arm=True,
+            can_disarm=True,
+        )
+    }
+
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=[area1, area2],
+        sensors=[sensor1, sensor2],
+        entry_id="test_master_disarm_auth_once",
+        users=users,
+        master_enabled=True,
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        hass.states.async_set("binary_sensor.area_1_door", "off")
+        hass.states.async_set("binary_sensor.area_2_door", "off")
+        await hass.async_block_till_done()
+
+        # Arm via master
+        await hass.services.async_call(
+            "alarm_control_panel",
+            "alarm_arm_away",
+            {"entity_id": "alarm_control_panel.master", "code": "1234"},
+            blocking=True,
+        )
+        await advance_time(hass, 1)
+
+        coordinator = hass.data[const.DOMAIN]["coordinator"]
+        original_auth = coordinator.async_authenticate_user
+        coordinator.async_authenticate_user = AsyncMock(wraps=original_auth)
+
+        # Disarm via master
+        await hass.services.async_call(
+            "alarm_control_panel",
+            "alarm_disarm",
+            {"entity_id": "alarm_control_panel.master", "code": "1234"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert coordinator.async_authenticate_user.call_count == 1
+        assert_alarm_state(hass, "alarm_control_panel.test_area_1_auth", "disarmed")
+        assert_alarm_state(hass, "alarm_control_panel.test_area_2_auth", "disarmed")
         assert_alarm_state(hass, "alarm_control_panel.master", "disarmed")

--- a/tests/test_user_permissions.py
+++ b/tests/test_user_permissions.py
@@ -435,3 +435,211 @@ async def test_text_code_format(hass: Any, enable_custom_integrations: Any) -> N
         state = hass.states.get(ALARM_ENTITY)
         assert state.state == "armed_away"
         assert state.attributes.get("changed_by") == "Text Code User"
+
+
+@pytest.mark.asyncio
+async def test_disarm_without_code_when_not_required(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Test disarm without code when not required."""
+    users = {
+        "admin_user": UserFactory.create_user(
+            user_id="admin_user",
+            name="Admin User",
+            code="1234",
+            can_arm=True,
+            can_disarm=True,
+        ),
+    }
+    areas = [
+        AreaFactory.create_area(
+            area_id="area_1",
+            name="Test Area 1",
+            code_disarm_required=False,
+            code_arm_required=True,
+        )
+    ]
+    sensors = [
+        SensorFactory.create_door_sensor(
+            entity_id=DOOR_SENSOR,
+            name="Door Sensor",
+            area="area_1",
+            modes=["armed_away", "armed_home"],
+            auto_bypass=False,
+            allow_open=False,
+            arm_on_close=False,
+            always_on=False,
+            trigger_unavailable=False,
+            use_exit_delay=True,
+            use_entry_delay=True,
+        )
+    ]
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=areas,
+        sensors=sensors,
+        entry_id="test_disarm_without_code_when_not_required",
+        users=users,
+    )
+    with patch_alarmo_integration_dependencies(storage):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        hass.states.async_set(DOOR_SENSOR, "off")
+        await hass.async_block_till_done()
+        await hass.services.async_call(
+            "alarmo",
+            "arm",
+            {"entity_id": ALARM_ENTITY, "code": "1234", "mode": "away"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        area = AreaFactory.create_area(area_id="area_1")
+        exit_time = area["modes"]["armed_away"]["exit_time"]
+        await advance_time(hass, exit_time + 1)
+        state = hass.states.get(ALARM_ENTITY)
+        assert state.state == "armed_away"
+        await hass.services.async_call(
+            "alarmo",
+            "disarm",
+            {"entity_id": ALARM_ENTITY},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        state = hass.states.get(ALARM_ENTITY)
+        assert state.state == "disarmed"
+        assert state.attributes.get("changed_by") is None
+
+
+@pytest.mark.asyncio
+async def test_arm_without_code_when_not_required(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Test arm without code when not required."""
+    users = {
+        "admin_user": UserFactory.create_user(
+            user_id="admin_user",
+            name="Admin User",
+            code="1234",
+            can_arm=True,
+            can_disarm=True,
+        ),
+    }
+    areas = [
+        AreaFactory.create_area(
+            area_id="area_1",
+            name="Test Area 1",
+            code_arm_required=False,
+        )
+    ]
+    sensors = [
+        SensorFactory.create_door_sensor(
+            entity_id=DOOR_SENSOR,
+            name="Door Sensor",
+            area="area_1",
+            modes=["armed_away", "armed_home"],
+            auto_bypass=False,
+            allow_open=False,
+            arm_on_close=False,
+            always_on=False,
+            trigger_unavailable=False,
+            use_exit_delay=True,
+            use_entry_delay=True,
+        )
+    ]
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=areas,
+        sensors=sensors,
+        entry_id="test_arm_without_code_when_not_required",
+        users=users,
+    )
+    with patch_alarmo_integration_dependencies(storage):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        hass.states.async_set(DOOR_SENSOR, "off")
+        await hass.async_block_till_done()
+        await hass.services.async_call(
+            "alarmo",
+            "arm",
+            {"entity_id": ALARM_ENTITY, "mode": "away"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        area = AreaFactory.create_area(area_id="area_1")
+        exit_time = area["modes"]["armed_away"]["exit_time"]
+        await advance_time(hass, exit_time + 1)
+        state = hass.states.get(ALARM_ENTITY)
+        assert state.state == "armed_away"
+        assert state.attributes.get("changed_by") is None
+
+
+@pytest.mark.asyncio
+async def test_mode_change_without_code_when_not_required(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Test mode change without code when not required."""
+    users = {
+        "admin_user": UserFactory.create_user(
+            user_id="admin_user",
+            name="Admin User",
+            code="1234",
+            can_arm=True,
+            can_disarm=True,
+        ),
+    }
+    areas = [
+        AreaFactory.create_area(
+            area_id="area_1",
+            name="Test Area 1",
+            code_mode_change_required=False,
+        )
+    ]
+    sensors = [
+        SensorFactory.create_door_sensor(
+            entity_id=DOOR_SENSOR,
+            name="Door Sensor",
+            area="area_1",
+            modes=["armed_away", "armed_home"],
+            auto_bypass=False,
+            allow_open=False,
+            arm_on_close=False,
+            always_on=False,
+            trigger_unavailable=False,
+            use_exit_delay=True,
+            use_entry_delay=True,
+        )
+    ]
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=areas,
+        sensors=sensors,
+        entry_id="test_mode_change_without_code_when_not_required",
+        users=users,
+    )
+    with patch_alarmo_integration_dependencies(storage):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        hass.states.async_set(DOOR_SENSOR, "off")
+        await hass.async_block_till_done()
+        await hass.services.async_call(
+            "alarmo",
+            "arm",
+            {"entity_id": ALARM_ENTITY, "code": "1234", "mode": "away"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        area = AreaFactory.create_area(area_id="area_1")
+        exit_time = area["modes"]["armed_away"]["exit_time"]
+        await advance_time(hass, exit_time + 1)
+        state = hass.states.get(ALARM_ENTITY)
+        assert state.state == "armed_away"
+        await hass.services.async_call(
+            "alarmo",
+            "arm",
+            {"entity_id": ALARM_ENTITY, "mode": "home"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        state = hass.states.get(ALARM_ENTITY)
+        assert state.state == "armed_home"
+        assert state.attributes.get("changed_by") is None


### PR DESCRIPTION
# Authentication Refactor
*This PR Fixes #1394. (Also relates to #1182)*

## TLDR

This refactor removes redundant bcrypt work during master disarm by centralizing code resolution and reusing the resolved user across areas, while preserving all existing permission checks and behaviors.

## Problem Statement

Alarmo validates a user code by iterating over all users and running `bcrypt.checkpw` until a match is found. When disarming **via the master entity**, the code is validated **once per area**. With multiple areas and multiple users, this produces a worst-case cost of:

```
O(n_area * n_user * bcrypt)
```

In addition, `async_authenticate_user` is synchronous on `main` and performs `concurrent.futures.as_completed(...)` directly on the event loop thread. 
The threadpool parallelizes the bcrypt work and **helps** reduce total latency, but the event loop still blocks while it waits for completion. So it improves the symptom without addressing the root cause.

## Solution Design

The refactor separates **authentication** from **authorization** and makes authentication **reusable**:

1. **Resolve code → user once** (authentication, uses bcrypt).
    - bcrypt work is offloaded via `hass.async_add_executor_job` to avoid blocking the event loop.
2. **Validate permissions per area** (authorization, no bcrypt):
   - `area_limit` must include the target area(s)
   - `can_disarm` / `can_arm` must be true for the requested action
3. **Propagate the resolved user** from the master entity to all areas on master disarm.

This ensures that master disarm performs at most **one** bcrypt resolution, while still enforcing per-area permissions.

## Important Changes

### 1) `custom_components/alarmo/alarm_control_panel.py`

- Added:
  - `_resolve_user_for_state(...)`: resolves `code → user` once (bcrypt) and validates permissions.
  - `_validate_user(...)`: authorization checks without bcrypt.
  - `_target_area_ids(...)`: helps validate the correct set of areas for master vs area entities.

- `async_alarm_disarm`:
  - Accepts an optional `user` parameter.
  - If `user` is provided, skips bcrypt and only checks permissions.

- `AlarmoMasterEntity.async_alarm_disarm`:
  - Resolves the user **once** at master level.
  - Propagates `user=...` to each area so bcrypt is not re-run.

- Arm actions (`arm_away`, `arm_home`, etc.) already flow through `async_handle_arm_request`, which now uses `_resolve_user_for_state`. This is consistent with the new pattern but the primary gain is for **master disarm**.
- A sync wrapper `alarm_disarm(...)` remains to preserve existing call sites; it now schedules the async implementation.

### 2) `custom_components/alarmo/__init__.py`

- User creation / code changes now hash codes off the event loop via `async_add_executor_job`.
- `async_authenticate_user(...)` is now explicitly async and runs the blocking bcrypt work in an executor.
- `_validate_user_code(...)` and `async_update_user_config(...)` are updated to await the async auth path.
- The previous per-call `ThreadPoolExecutor` was removed to reduce overhead.
- Push-action handlers now `await` the async arm/disarm methods to match the new async signatures.

### 3) `custom_components/alarmo/websockets.py`

- `async_update_user_config(...)` is now awaited, matching its new async signature.

### 4) `tests/test_alarm_master.py`

- Added tests to cover the new auth flow on the master entity:
  - `test_alarm_master_disarm_denied_for_area_limited_user`: a user limited to `area_1` cannot disarm the master when multiple areas are armed.
  - `test_alarm_master_disarm_auth_resolved_once`: master disarm resolves the code only once and reuses the user for all areas.
 
### 5) `tests/factories.py`

- Mock storage includes user CRUD helpers used by the coordinator.

## Additional Information

- **`skip_code=True`** still bypasses validation entirely (previous behavior). This is intentional for internal flows like push actions.
- **Permissions are still enforced per area** even when the user is propagated, ensuring `area_limit` is respected.
- The refactor is focused on **master disarm latency**; area disarm still resolves the code locally, as expected.
- Any external callers using `async_update_user_config(...)` must now await it (the websocket handler was updated accordingly).
- The coordinator includes a thin wrapper `_authenticate_user_sync(...)` that currently just forwards to `_do_authenticate(...)`. It exists to make the “executor-only” contract explicit, but can be collapsed into a single method if reviewers prefer.

## Profiler Results (Before vs After)

### Reproduction steps (thank to @jguillen-lab) :

1. Install Alarmo and configure 5 users with PIN codes.
2. Configure at least 3 areas + master alarm
3. Enable the `profiler` integration.
4. Arm the alarm.
5. In Developer Tools → Services, call `profiler.start` with `seconds: 10`.
6. Immediately disarm using a valid PIN code.

### From the `.cprof` analysis:

#### Before:

```
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    20/4    0.625    0.031    0.314    0.078 {built-in method bcrypt._bcrypt.checkpw}
```

#### After:

```
     ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2       0.163    0.081    0.163    0.081 {built-in method bcrypt._bcrypt.checkpw}
```

#### Note: 
- this reflects the shift from worst-case `n_user × n_area` bcrypt checks during master disarm to `n_user` checks max (code resolved once, permissions checked per area).
- difference is not huge in tot time but these tests were run on my development environment which is quite fast. It's better to consider the amount of `ncalls`.
