### PR TITLE
workflow: add frontend build and linter check to GitHub Actions

### DIFF
--- a/.github/workflows/frontend-build.yaml
+++ b/.github/workflows/frontend-build.yaml
@@ -1,0 +1,33 @@
+name: Frontend Build Check
+
+on:
+  pull_request:
+    paths:
+      - 'custom_components/alarmo/frontend/**'
+  push:
+    paths:
+      - 'custom_components/alarmo/frontend/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        working-directory: custom_components/alarmo/frontend
+        run: npm install
+
+      - name: Run linter check
+        working-directory: custom_components/alarmo/frontend
+        run: npm run lint:check
+
+      - name: Build frontend
+        working-directory: custom_components/alarmo/frontend
+        run: npm run build

--- a/custom_components/alarmo/frontend/package.json
+++ b/custom_components/alarmo/frontend/package.json
@@ -9,6 +9,7 @@
     "rollup": "rollup -c",
     "babel": "./node_modules/.bin/babel dist/alarm-panel.js --out-file dist/alarm-panel.js",
     "lint": "eslint src/**/*.ts --fix",
+    "lint:check": "eslint src/**/*.ts",
     "start": "rollup -c --watch"
   },
   "repository": {


### PR DESCRIPTION
While fixing the frontend dependancies issues. I think it would be a good idea to have some automatic workflow that run linter checks, and even check that the frontend is still buildable.

This PR adds such a workflow, however, since the frontend is not buildable right now on main branch, it would be better to merge this PR after #1401 