### PR TITLE
Guard against None alarm_entity in ready_to_arm_modes_changed

### DIFF
--- a/custom_components/alarmo/event.py
+++ b/custom_components/alarmo/event.py
@@ -33,11 +33,10 @@ class EventHandler:
             alarm_entity = self.hass.data[const.DOMAIN]["master"]
 
         if alarm_entity is None:
-            _LOGGER.debug(
-                "Ignoring %s for area %s: alarm entity is None "
-                "(likely removed or master not configured)",
-                event,
+            _LOGGER.warning(
+                "Cannot resolve alarm_entity for area_id: %s (event: %s)",
                 area_id,
+                event,
             )
             return
 

--- a/custom_components/alarmo/event.py
+++ b/custom_components/alarmo/event.py
@@ -32,6 +32,15 @@ class EventHandler:
         else:
             alarm_entity = self.hass.data[const.DOMAIN]["master"]
 
+        if alarm_entity is None:
+            _LOGGER.debug(
+                "Ignoring %s for area %s: alarm entity is None "
+                "(likely removed or master not configured)",
+                event,
+                area_id,
+            )
+            return
+
         if event in [
             const.EVENT_FAILED_TO_ARM,
             const.EVENT_COMMAND_NOT_ALLOWED,
@@ -75,12 +84,6 @@ class EventHandler:
             self.hass.bus.async_fire("alarmo_command_success", data)
 
         elif event == const.EVENT_READY_TO_ARM_MODES_CHANGED:
-            if alarm_entity is None:
-                _LOGGER.debug(
-                    "Ignoring ready_to_arm_modes_changed for area %s: alarm entity is None (likely removed or master not configured)",
-                    area_id,
-                )
-                return
             supported_modes = dict(
                 filter(
                     lambda el: el[1] & alarm_entity.supported_features,

--- a/custom_components/alarmo/event.py
+++ b/custom_components/alarmo/event.py
@@ -1,9 +1,13 @@
 """fire events in HA for use with automations."""
 
+import logging
+
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from . import const
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class EventHandler:
@@ -71,6 +75,12 @@ class EventHandler:
             self.hass.bus.async_fire("alarmo_command_success", data)
 
         elif event == const.EVENT_READY_TO_ARM_MODES_CHANGED:
+            if alarm_entity is None:
+                _LOGGER.debug(
+                    "Ignoring ready_to_arm_modes_changed for area %s: alarm entity is None (likely removed or master not configured)",
+                    area_id,
+                )
+                return
             supported_modes = dict(
                 filter(
                     lambda el: el[1] & alarm_entity.supported_features,


### PR DESCRIPTION
## Problem

`EventHandler.async_handle_ready_to_arm_modes_changed` looks up the alarm entity for the given area and then accesses `alarm_entity.supported_features`. When the area is the master and no children are configured yet, or when the area entity has been removed at runtime, the lookup returns `None` and the subsequent attribute access raises, which kills the event handler.

## Fix

Add an early return with a debug log when `alarm_entity` is `None`. Same approach as the existing PR #1373 — posting as a separate PR for visibility while that one is idle.

## Behavior

- Normal setup with configured areas: unchanged.
- Master area with no children: event is silently ignored and a debug log line is emitted instead of a traceback.
- Entity removed mid-session: same.

## References

- References #1373