### PR TITLE
fix(auth): restore threading for bcrypt work from #1182

### DIFF
--- a/custom_components/alarmo/__init__.py
+++ b/custom_components/alarmo/__init__.py
@@ -3,6 +3,7 @@
 import re
 import base64
 import logging
+import concurrent.futures
 
 import bcrypt
 from homeassistant.core import (
@@ -48,6 +49,8 @@ from .automations import AutomationHandler
 
 _LOGGER = logging.getLogger(__name__)
 
+# Max number of threads to start when checking user codes.
+MAX_WORKERS = 4
 # Number of rounds of hashing when computing user hashes.
 BCRYPT_NUM_ROUNDS = 10
 
@@ -369,11 +372,17 @@ class AlarmoCoordinator(DataUpdateCoordinator):
                 return check_user_code(self.store.async_get_user(user_id), code)
 
             users = self.store.async_get_users()
-            for user in users.values():
-                result = check_user_code(user, code)
-                if result:
-                    return result
-            return None
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=MAX_WORKERS
+            ) as executor:
+                futures = [
+                    executor.submit(check_user_code, user, code)
+                    for user in users.values()
+                ]
+                for future in concurrent.futures.as_completed(futures):
+                    if future.result():
+                        executor.shutdown(wait=False, cancel_futures=True)
+                        return future.result()
 
         return await self.hass.async_add_executor_job(_authenticate_user_sync)
 


### PR DESCRIPTION
Following the feedback of @therealmrfox in #1394 

I assume there is obviously a win by manually threading the bcrypt work on some setup and configuration (e.g. many alarmo codes to check and a weak HW such as RPI)

while I still think it's better to offload this check via `hass.async_add_executor_job` since it prevent this work to block the event loop. It seems that it is still a good improvement to parallelize codes validations to speed up the code/user resolution.

I don't see any way to handle this with a cleaner way at this moment.

Since this code lived in Alarmo for a while without raising any issues : 
I propose to add it back so users still benefit from the parallelization added by @therealmrfox while we still avoid blocking the event loop, and we still avoid resolving the code multiple times when called on Alarmo's master entity.