### PR TITLE
feat(i18n): add Portuguese translation for Alarmo services

### DIFF
--- a/custom_components/alarmo/translations/pt.json
+++ b/custom_components/alarmo/translations/pt.json
@@ -1,0 +1,85 @@
+{
+  "services": {
+    "arm": {
+      "name": "Armar",
+      "description": "Armar uma entidade do Alarmo com configurações personalizadas.",
+      "fields": {
+        "entity_id": {
+          "name": "ID da Entidade",
+          "description": "Entidade de alarme a ser armada."
+        },
+        "code": {
+          "name": "Código",
+          "description": "Código utilizado para armar."
+        },
+        "mode": {
+          "name": "Modo",
+          "description": "Modo em que o alarme será armado."
+        },
+        "skip_delay": {
+          "name": "Ignorar Atraso",
+          "description": "Ignorar o atraso de saída."
+        },
+        "force": {
+          "name": "Forçar",
+          "description": "Ignorar automaticamente todos os sensores que impedem a operação de armar."
+        }
+      }
+    },
+    "disarm": {
+      "name": "Desarmar",
+      "description": "Desarmar uma entidade do Alarmo.",
+      "fields": {
+        "entity_id": {
+          "name": "ID da Entidade",
+          "description": "Entidade de alarme a ser desarmada."
+        },
+        "code": {
+          "name": "Código",
+          "description": "Código utilizado para desarmar."
+        }
+      }
+    },
+    "skip_delay": {
+      "name": "Ignorar Atraso",
+      "description": "Ignora o tempo de atraso restante e avança diretamente para o próximo estado. Só tem efeito quando o alarme está no estado a armar ou pendente.",
+      "fields": {
+        "entity_id": {
+          "name": "ID da Entidade",
+          "description": "Entidade de alarme para a qual o atraso deve ser ignorado."
+        }
+      }
+    },
+    "enable_user": {
+      "name": "Ativar Utilizador",
+      "description": "Permitir que um utilizador arme/desarme o Alarmo.",
+      "fields": {
+        "name": {
+          "name": "Nome",
+          "description": "Nome do utilizador a ativar."
+        }
+      }
+    },
+    "disable_user": {
+      "name": "Desativar Utilizador",
+      "description": "Bloquear um utilizador de armar/desarmar o Alarmo.",
+      "fields": {
+        "name": {
+          "name": "Nome",
+          "description": "Nome do utilizador a desativar."
+        }
+      }
+    }
+  },
+  "selector": {
+    "arm_mode": {
+      "options": {
+        "away": "Armado Fora",
+        "night": "Armado Noturno",
+        "home": "Armado Em Casa",
+        "vacation": "Armado Férias",
+        "custom": "Armado Personalizado"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a new Portuguese (`pt.json`) translation file for the Alarmo custom component. The file provides localized strings for service names, descriptions, and field labels, as well as arm mode selector options, making the Alarmo interface accessible to Portuguese-speaking users.

**Localization:**

* Added a comprehensive Portuguese translation file (`pt.json`) covering service names, descriptions, and field labels for Alarmo services such as `arm`, `disarm`, `skip_delay`, `enable_user`, and `disable_user`.
* Included Portuguese translations for arm mode selector options, such as "Armado Fora", "Armado Noturno", "Armado Em Casa", "Armado Férias", and "Armado Personalizado".