### PR TITLE
Second attempt to fix override code not working

### DIFF
--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -176,7 +176,6 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
         self._revert_state = None
         self._ready_to_arm_modes = []
         self._last_triggered = None
-        self._validated_user = None
 
     @property
     def device_info(self) -> dict:
@@ -324,8 +323,10 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
     async def _validate_code(self, code, to_state):  # noqa PLR0911
         """Validate code and user permissions for a requested state change.
 
-        Returns a (success, error_event) tuple. When success is True,
-        error_event is None.
+        Returns a (success, info) tuple. 
+        When validation is successful, success is True, otherwise False.
+        When success is True, info is the user data (or None if no user/code was needed).
+        When success is False, info is the error event.
         """
         # check bypass rules
         if (
@@ -405,11 +406,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
 
         # success
         self._changed_by = user[ATTR_NAME]
-        
-        # store the validated user for the function caller
-        self._validated_user = user
-        
-        return True, None
+        return True, user
 
     async def async_service_disarm_handler(self, code, context_id=None):
         """Handle external disarm request from alarmo.disarm service."""
@@ -583,7 +580,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
                     self.open_sensors = None
                     self.schedule_update_ha_state()
                 return False
-            elif self._validated_user and self._validated_user.get(const.ATTR_IS_OVERRIDE_CODE, False):
+            elif info and info[const.ATTR_IS_OVERRIDE_CODE]:
                 bypass_open_sensors = True
         else:
             self._changed_by = None

--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -176,6 +176,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
         self._revert_state = None
         self._ready_to_arm_modes = []
         self._last_triggered = None
+        self._validated_user = None
 
     @property
     def device_info(self) -> dict:
@@ -404,6 +405,10 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
 
         # success
         self._changed_by = user[ATTR_NAME]
+        
+        # store the validated user for the function caller
+        self._validated_user = user
+        
         return True, None
 
     async def async_service_disarm_handler(self, code, context_id=None):
@@ -578,7 +583,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
                     self.open_sensors = None
                     self.schedule_update_ha_state()
                 return False
-            elif info and info[const.ATTR_IS_OVERRIDE_CODE]:
+            elif self._validated_user and self._validated_user.get(const.ATTR_IS_OVERRIDE_CODE, False):
                 bypass_open_sensors = True
         else:
             self._changed_by = None


### PR DESCRIPTION
Managed to sit down and actually look at this properly (for Issue #1430). Previous attempt was PR #1435 but that was just a quick temporary fix so we could use the alarm and I missed the documentation of the function I changed.

The problem seems to be that the function 
```
async def async_handle_arm_request(self, arm_mode, **kwargs): ...
```

contains 

```
(res, info) = await self._validate_code(code, arm_mode)
```

and then checks the override code with 

```
elif info and info[const.ATTR_IS_OVERRIDE_CODE]:
    bypass_open_sensors = True
```

But the documentation says  that `_validate_code` returns a (success, error_event) tuple. So there is never a valid `info` parameter because it's just returning `None`. 

To fix this, I have added a new attribute `self._validated_user` which is initialised to None originally, but on a successful authentication, it stores the user that tried to arm the system. From this, the user info can be checked by the original caller function to see if it contains the override code attribute. 

Again, I have tried to test this the best I can and it seems to work correctly for me, but would appreciate some feedback from others!