### PR TITLE
Add attribute "active_when_armed" which can be used as a wildcard for notifications

### DIFF
--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -270,6 +270,24 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
         else:
             self._open_sensors = {}
 
+##########NEW ADDITION
+    @property
+    def active_when_armed(self):
+        """Get allowed open."""
+        if not self._active_when_armed:
+            return None
+        else:
+            return self._active_when_armed
+
+    @active_when_armed.setter
+    def active_when_armed(self, value):
+        """Set active_when_armed."""
+        if type(value) is list:
+            self._active_when_armed = value
+        elif not value:
+            self._active_when_armed = None
+###################
+    
     @property
     def bypassed_sensors(self):
         """Get bypassed sensors."""
@@ -315,6 +333,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             "arm_mode": self.arm_mode,
             "next_state": self.next_state,
             "open_sensors": self.open_sensors,
+            "active_when_armed": self.active_when_armed,  #new addition
             "bypassed_sensors": self.bypassed_sensors,
             "delay": self.delay,
             "last_triggered": self.last_triggered,
@@ -466,6 +485,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
         else:
             self.open_sensors = None
             self.bypassed_sensors = None
+            self.active_when_armed = None #########New addition
             self.async_update_state(AlarmControlPanelState.DISARMED)
             if self.changed_by:
                 _LOGGER.info(
@@ -592,6 +612,7 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
             self._revert_state = AlarmControlPanelState.DISARMED
             self.open_sensors = None
             self.bypassed_sensors = None
+            self.active_when_armed = None ### New addition
 
         self.async_arm(
             arm_mode,
@@ -725,6 +746,10 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
                 self._bypassed_sensors = state.attributes["bypassed_sensors"]
             if "last_triggered" in state.attributes:
                 self._last_triggered = state.attributes["last_triggered"]
+            #####NEW ADDITION
+            if "active_when_armed" in state.attributes:
+                self.active_when_armed = state.attributes["active_when_armed"]
+            #########
 
     async def async_will_remove_from_hass(self):
         """Disconnect entity object when removed."""
@@ -913,9 +938,9 @@ class AlarmoAreaEntity(AlarmoBaseEntity):
         exit_delay = int(self._config[const.ATTR_MODES][arm_mode]["exit_time"] or 0)
 
         if skip_delay or not exit_delay:
-            # immediate arm event
+            # immediate arm event #active new addition
 
-            (open_sensors, bypassed_sensors) = self.hass.data[const.DOMAIN][
+            (open_sensors, bypassed_sensors, active_when_armed) = self.hass.data[const.DOMAIN][
                 "sensor_handler"
             ].validate_arming_event(
                 area_id=self.area_id,
@@ -936,6 +961,8 @@ class AlarmoAreaEntity(AlarmoBaseEntity):
                 # proceed the arm
                 if bypassed_sensors:
                     self.bypassed_sensors = bypassed_sensors
+                if active_when_armed: #######New addition
+                    self.active_when_armed = active_when_armed #####
                 self.open_sensors = open_sensors if open_sensors else None
                 if self.changed_by:
                     _LOGGER.info(
@@ -965,8 +992,8 @@ class AlarmoAreaEntity(AlarmoBaseEntity):
                 self.async_update_state(arm_mode)
                 return True
 
-        else:  # normal arm event (from disarmed via arming)
-            (open_sensors, _bypassed_sensors) = self.hass.data[const.DOMAIN][
+        else:  # normal arm event (from disarmed via arming) #active new addition
+            (open_sensors, _bypassed_sensors, active_when_armed) = self.hass.data[const.DOMAIN][
                 "sensor_handler"
             ].validate_arming_event(
                 area_id=self.area_id,

--- a/custom_components/alarmo/automations.py
+++ b/custom_components/alarmo/automations.py
@@ -303,7 +303,19 @@ class AutomationHandler:
                     parts.append(name)
                 bypassed_sensors = ", ".join(parts)
             input = input.replace("{{bypassed_sensors}}", bypassed_sensors)
-
+##########
+        # process wildcard '{{active_when_armed}}'
+        if "{{active_when_armed}}" in input:
+            active_when_armed = ""
+            if alarm_entity.active_when_armed and len(alarm_entity.active_when_armed):
+                parts = []
+                for entity_id in alarm_entity.active_when_armed:
+                    name = friendly_name_for_entity_id(entity_id, self.hass)
+                    parts.append(name)
+                active_when_armed = "Open: " + ", ".join(parts)
+            input = input.replace("{{active_when_armed}}", active_when_armed)
+##############
+        
         # process wildcard '{{arm_mode}}'
         res = re.search(r"{{arm_mode(\|lang=([^}]+))?}}", input)
         if res:

--- a/custom_components/alarmo/sensors.py
+++ b/custom_components/alarmo/sensors.py
@@ -303,6 +303,7 @@ class SensorHandler:
         sensors_list = self.active_sensors_for_alarm_state(area_id, target_state)
         open_sensors = {}
         bypassed_sensors = []
+        active_when_armed = []##########New addition
 
         alarm_state = target_state
         if use_delay and alarm_state in const.ARM_MODES:
@@ -330,11 +331,12 @@ class SensorHandler:
                     bypassed_sensors.append(entity)
                 elif sensor_config[ATTR_ALLOW_OPEN] and sensor_state == STATE_OPEN:
                     # sensor is permitted to be open during/after arming
+                    active_when_armed.append(entity) ###########NEW ADDITION
                     continue
                 else:
                     open_sensors[entity] = sensor_state
 
-        return (open_sensors, bypassed_sensors)
+        return (open_sensors, bypassed_sensors, active_when_armed) ##active new
 
     def get_entry_delay_for_trigger(
         self, open_sensors: dict[str, str], area_id: str, arm_mode: str


### PR DESCRIPTION
An atrribute added to Alarmo control panel that records the sensors that are active during an arm event. This would function similarly to the attribute bypassed_sensor. Works for sensors set as "allow open initially" in Alarmo sensor settings. Solves https://github.com/nielsfaber/alarmo/issues/845 


<img width="1584" height="379" alt="image" src="https://github.com/user-attachments/assets/cc896f24-a8c0-402d-9b80-f9b7d429302c" />

<img width="629" height="549" alt="image" src="https://github.com/user-attachments/assets/c3932309-703f-41bd-8478-51466be27752" />

<img width="308" height="200" alt="image" src="https://github.com/user-attachments/assets/205db240-8254-4774-ba77-4c4b836c66c3" />


