### PR TITLE
fix: prevent KeyError on load when an area mode omits trigger_time

### DIFF
--- a/custom_components/alarmo/store.py
+++ b/custom_components/alarmo/store.py
@@ -381,10 +381,10 @@ class AlarmoStorage:
                 for area in data["areas"]:
                     modes = {
                         mode: ModeEntry(
-                            enabled=config["enabled"],
-                            exit_time=config["exit_time"],
-                            entry_time=config["entry_time"],
-                            trigger_time=config["trigger_time"],
+                            enabled=config.get("enabled", False),
+                            exit_time=config.get("exit_time", None),
+                            entry_time=config.get("entry_time", None),
+                            trigger_time=config.get("trigger_time", None),
                         )
                         for (mode, config) in area["modes"].items()
                     }

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,84 @@
+"""Tests for Alarmo storage loading."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.alarmo.store import AlarmoStorage
+
+
+@pytest.mark.asyncio
+async def test_async_load_area_modes_with_missing_keys(hass: Any) -> None:
+    """Area modes stored with missing keys must load instead of raising.
+
+    Regression for a ``KeyError`` in ``AlarmoStorage.async_load``: area modes
+    were rebuilt with unconditional ``config["trigger_time"]`` (and enabled/
+    exit_time/entry_time). ``trigger_time`` is ``vol.Optional`` in the area
+    schema, and a disabled mode is persisted without it, so on the next load
+    ``async_load`` raised ``KeyError`` and the config entry failed setup. This
+    runs on every load, not just a version migration. The all-keys-missing case
+    below is extra defensive coverage.
+    """
+    stored_data = {
+        "config": {
+            "code_arm_required": False,
+            "code_mode_change_required": False,
+            "code_disarm_required": False,
+            "code_format": "number",
+            "disarm_after_trigger": False,
+        },
+        "areas": [
+            {
+                "area_id": "area_1",
+                "name": "Test Area",
+                "modes": {
+                    # missing trigger_time (the real incident: a disabled mode)
+                    "armed_home": {
+                        "enabled": False,
+                        "exit_time": None,
+                        "entry_time": None,
+                    },
+                    # missing every key
+                    "armed_night": {},
+                    # fully specified with falsy values that must be preserved
+                    "armed_away": {
+                        "enabled": False,
+                        "exit_time": 0,
+                        "entry_time": 0,
+                        "trigger_time": 0,
+                    },
+                },
+            }
+        ],
+    }
+
+    storage = AlarmoStorage(hass)
+
+    with patch.object(
+        storage._store, "async_load", AsyncMock(return_value=stored_data)
+    ):
+        await storage.async_load()
+
+    modes = storage.async_get_area("area_1")["modes"]
+
+    # Missing keys fall back to the ModeEntry defaults (enabled=False, others None).
+    assert modes["armed_home"] == {
+        "enabled": False,
+        "exit_time": None,
+        "entry_time": None,
+        "trigger_time": None,
+    }
+    assert modes["armed_night"] == {
+        "enabled": False,
+        "exit_time": None,
+        "entry_time": None,
+        "trigger_time": None,
+    }
+    # Present falsy values (0) are preserved, not clobbered.
+    assert modes["armed_away"] == {
+        "enabled": False,
+        "exit_time": 0,
+        "entry_time": 0,
+        "trigger_time": 0,
+    }


### PR DESCRIPTION
## Summary

Fixes a `KeyError: 'trigger_time'` that puts Alarmo into `setup_error` on start when an area mode is stored without a `trigger_time` key.

`AlarmoStorage.async_load()` rebuilt each area mode with unconditional dict access:

```python
ModeEntry(
    enabled=config["enabled"],
    exit_time=config["exit_time"],
    entry_time=config["entry_time"],
    trigger_time=config["trigger_time"],   # KeyError if absent
)
```

`trigger_time` is `vol.Optional` in the area `mode_schema` and a **disabled** mode is persisted without it, so the record read back on the next start raised `KeyError` and the config entry failed setup. This is in `async_load` (runs on **every** load), not a version migration.

## Fix

Use `config.get(key, <default>)` with the `ModeEntry` attr defaults (`enabled=False`; `exit_time`/`entry_time`/`trigger_time` `None`). A missing key now falls back to exactly the value a directly-constructed `ModeEntry` would have — so **no new runtime state** is introduced — while present falsy values (`0`/`False`) are preserved (`.get(default)`, not `or`).

```diff
-                            enabled=config["enabled"],
-                            exit_time=config["exit_time"],
-                            entry_time=config["entry_time"],
-                            trigger_time=config["trigger_time"],
+                            enabled=config.get("enabled", False),
+                            exit_time=config.get("exit_time", None),
+                            entry_time=config.get("entry_time", None),
+                            trigger_time=config.get("trigger_time", None),
```

## Test

Adds `tests/test_store.py`, using the existing `hass` fixture, that loads an area whose modes are missing keys and asserts they fall back to the `ModeEntry` defaults while explicit falsy values are preserved. It covers a mode missing `trigger_time` (the real disabled-mode case), a mode missing every key (defensive), and a mode with explicit `0`s.

Verified in the repo's `uv` env:
- `uv run pytest tests/` → **97 passed** (this test + the existing suite)
- `uv run ruff check` / `ruff format --check` → clean
- Reverting the fix reproduces `KeyError: 'trigger_time'` at `store.py:387`, so the test genuinely guards the regression.

Closes #1448
