### PR TITLE
fix: skip allow_open sensors on startup evaluation to prevent false triggers

### DIFF
--- a/custom_components/alarmo/sensors.py
+++ b/custom_components/alarmo/sensors.py
@@ -740,6 +740,13 @@ class SensorHandler:
                 # Skip unknown sensors - they'll be handled when they become known
                 continue
 
+            if sensor_config[ATTR_ALLOW_OPEN] and sensor_state == STATE_OPEN:
+                _LOGGER.debug(
+                    "Sensor %s is open with allow_open, skipping startup eval",
+                    entity_id,
+                )
+                continue
+
             # Check if sensor state is allowed in current alarm state
             res = sensor_state_allowed(sensor_state, sensor_config, alarm_entity.state)
 

--- a/tests/test_startup_sensor_evaluation.py
+++ b/tests/test_startup_sensor_evaluation.py
@@ -427,3 +427,143 @@ async def test_sensor_closed_on_startup_no_trigger(
         await hass.async_block_till_done()
         assert_alarm_state(hass, ALARM_ENTITY, "disarmed")
         await cleanup_timers(hass)
+
+
+@pytest.mark.asyncio
+async def test_allow_open_sensor_on_startup_does_not_trigger(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Test that an allow_open sensor open on startup does NOT trigger the alarm.
+
+    Scenario: Sensor with allow_open=True is open when integration starts
+    with alarm in armed state.
+    Expected: Alarm stays armed (allow_open sensors are permitted to be open).
+    """
+    area = AreaFactory.create_area(area_id="area_1", name="Test Area 1")
+    sensor_config = SensorFactory.create_door_sensor(
+        entity_id=GENERIC_DOOR_SENSOR,
+        name="Generic Area 1 Door",
+        area="area_1",
+        modes=["armed_away", "armed_home"],
+        always_on=False,
+        auto_bypass=False,
+        auto_bypass_modes=[],
+        allow_open=True,  # Sensor is allowed to be open
+        trigger_unavailable=False,
+        arm_on_close=False,
+        use_exit_delay=False,
+        use_entry_delay=False,  # Immediate trigger to make test stricter
+    )
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=[area],
+        sensors=[sensor_config],
+        entry_id="test_allow_open_on_startup",
+    )
+
+    # Mock the alarm entity's last state
+    mock_restore_cache(
+        hass,
+        [
+            State(ALARM_ENTITY, "armed_away", {"arm_mode": "armed_away"}),
+        ],
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        # Set sensor to open BEFORE integration starts
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "on")
+        await hass.async_block_till_done()
+
+        # Setup the integration
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Give the startup evaluation time to process
+        await advance_time(hass, 2)
+
+        # Alarm should still be armed (allow_open sensor should be ignored)
+        assert_alarm_state(hass, ALARM_ENTITY, "armed_away")
+
+        # Cleanup
+        await hass.services.async_call(
+            "alarmo",
+            "disarm",
+            {
+                "entity_id": ALARM_ENTITY,
+                "code": "1234",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert_alarm_state(hass, ALARM_ENTITY, "disarmed")
+        await cleanup_timers(hass)
+
+
+@pytest.mark.asyncio
+async def test_allow_open_sensor_closed_on_startup_stays_armed(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Test that an allow_open sensor CLOSED on startup stays armed.
+
+    Scenario: Sensor with allow_open=True is closed when integration starts
+    with alarm in armed state.
+    Expected: Alarm stays armed (sensor is not in violation).
+    """
+    area = AreaFactory.create_area(area_id="area_1", name="Test Area 1")
+    sensor_config = SensorFactory.create_door_sensor(
+        entity_id=GENERIC_DOOR_SENSOR,
+        name="Generic Area 1 Door",
+        area="area_1",
+        modes=["armed_away", "armed_home"],
+        always_on=False,
+        auto_bypass=False,
+        auto_bypass_modes=[],
+        allow_open=True,  # Sensor is allowed to be open
+        trigger_unavailable=False,
+        arm_on_close=False,
+        use_exit_delay=True,
+        use_entry_delay=True,
+    )
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=[area],
+        sensors=[sensor_config],
+        entry_id="test_allow_open_closed_on_startup",
+    )
+
+    # Mock the alarm entity's last state
+    mock_restore_cache(
+        hass,
+        [
+            State(ALARM_ENTITY, "armed_away", {"arm_mode": "armed_away"}),
+        ],
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        # Set sensor closed BEFORE integration starts
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "off")
+        await hass.async_block_till_done()
+
+        # Setup the integration
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Give the startup evaluation time to process
+        await advance_time(hass, 2)
+
+        # Alarm should still be armed (no violations)
+        assert_alarm_state(hass, ALARM_ENTITY, "armed_away")
+
+        # Cleanup
+        await hass.services.async_call(
+            "alarmo",
+            "disarm",
+            {
+                "entity_id": ALARM_ENTITY,
+                "code": "1234",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert_alarm_state(hass, ALARM_ENTITY, "disarmed")
+        await cleanup_timers(hass)


### PR DESCRIPTION
## Description

When Home Assistant restarts and sensors configured with "Allow open initially" (`allow_open: True`) are still open, Alarmo triggers the alarm unnecessarily. These sensors were open before the restart and should be allowed to remain open without triggering.

## Fix

In `_async_evaluate_armed_state_on_startup()` (`sensors.py`), added a check to skip sensors with `allow_open=True` that are currently open. This matches the existing behavior in `validate_arming_event()` which already handles `allow_open` correctly during normal arming.

## Related Issue

Fixes #1419