### PR TITLE
fix: do not ignore sensor transitions from unknown to open

### DIFF
--- a/custom_components/alarmo/sensors.py
+++ b/custom_components/alarmo/sensors.py
@@ -377,15 +377,28 @@ class SensorHandler:
         new_state = parse_sensor_state(event.data["new_state"])
         sensor_config = self._config[entity]
         if old_state == STATE_UNKNOWN:
-            # sensor is unknown at startup,
-            #   state which comes after is considered as initial state
-            _LOGGER.debug(
-                "Initial state for %s is %s",
-                entity,
-                new_state,
-            )
-            self.update_ready_to_arm_status(sensor_config["area"])
-            return
+            if new_state not in (STATE_OPEN, STATE_UNAVAILABLE) or (
+                sensor_config[ATTR_ALLOW_OPEN] and new_state == STATE_OPEN
+            ):
+                # transition to a safe state, or to open while the sensor is
+                #   allowed to be open — treat as initial state
+                _LOGGER.debug(
+                    "Initial state for %s is %s",
+                    entity,
+                    new_state,
+                )
+                self.update_ready_to_arm_status(sensor_config["area"])
+                return
+            else:
+                # transition to a violation state — do not treat as initial,
+                #   proceed through normal trigger evaluation
+                _LOGGER.debug(
+                    "Sensor %s recovered from unknown to %s while alarm is %s, "
+                    "evaluating as live state change",
+                    entity,
+                    new_state,
+                    self.hass.data[const.DOMAIN]["areas"][sensor_config["area"]].state,
+                )
         if old_state == new_state:
             # not a state change - ignore
             return

--- a/tests/test_startup_sensor_evaluation.py
+++ b/tests/test_startup_sensor_evaluation.py
@@ -427,3 +427,335 @@ async def test_sensor_closed_on_startup_no_trigger(
         await hass.async_block_till_done()
         assert_alarm_state(hass, ALARM_ENTITY, "disarmed")
         await cleanup_timers(hass)
+
+
+@pytest.mark.asyncio
+async def test_sensor_transition_from_unknown_to_open_triggers_alarm(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Test that transitioning from unknown to open triggers the alarm.
+
+    Scenario: Sensor recovers from unknown state to open while alarm is armed.
+    Expected: Alarm should trigger (entry delay then triggered).
+    """
+    area = AreaFactory.create_area(
+        area_id="area_1",
+        name="Test Area 1",
+        armed_away_entry_time=10,
+    )
+    sensor_config = SensorFactory.create_door_sensor(
+        entity_id=GENERIC_DOOR_SENSOR,
+        name="Generic Area 1 Door",
+        area="area_1",
+        modes=["armed_away", "armed_home"],
+        always_on=False,
+        auto_bypass=False,
+        auto_bypass_modes=[],
+        allow_open=False,
+        trigger_unavailable=False,
+        arm_on_close=False,
+        use_exit_delay=True,
+        use_entry_delay=True,
+    )
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=[area],
+        sensors=[sensor_config],
+        entry_id="test_unknown_to_open",
+    )
+
+    # Mock the alarm entity's last state (simulates it was armed before)
+    mock_restore_cache(
+        hass,
+        [
+            State(ALARM_ENTITY, "armed_away", {"arm_mode": "armed_away"}),
+        ],
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        # Set sensor to unknown BEFORE integration starts
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "unknown")
+        await hass.async_block_till_done()
+
+        # Setup the integration
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Give the startup evaluation a moment to process
+        await advance_time(hass, 1)
+
+        # Alarm should be armed (sensor was unknown, skipped on startup)
+        assert_alarm_state(hass, ALARM_ENTITY, "armed_away")
+
+        # Now change sensor from unknown to open (simulates recovery)
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "on")
+        await hass.async_block_till_done()
+        await advance_time(hass, 1)
+
+        # Alarm should now be in pending (entry delay)
+        assert_alarm_state(hass, ALARM_ENTITY, "pending")
+
+        # Advance past entry delay to trigger
+        await advance_time(hass, area["modes"]["armed_away"]["entry_time"] + 1)
+        assert_alarm_state(hass, ALARM_ENTITY, "triggered")
+
+        # Cleanup
+        await hass.services.async_call(
+            "alarmo",
+            "disarm",
+            {
+                "entity_id": ALARM_ENTITY,
+                "code": "1234",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert_alarm_state(hass, ALARM_ENTITY, "disarmed")
+        await cleanup_timers(hass)
+
+
+@pytest.mark.asyncio
+async def test_sensor_transition_from_unknown_to_closed_does_not_trigger(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Test that transitioning from unknown to closed does not trigger alarm.
+
+    Scenario: Sensor recovers from unknown state to closed (safe state) while
+    alarm is armed.
+    Expected: Alarm stays armed (initial state behavior preserved for safe states).
+    """
+    area = AreaFactory.create_area(area_id="area_1", name="Test Area 1")
+    sensor_config = SensorFactory.create_door_sensor(
+        entity_id=GENERIC_DOOR_SENSOR,
+        name="Generic Area 1 Door",
+        area="area_1",
+        modes=["armed_away", "armed_home"],
+        always_on=False,
+        auto_bypass=False,
+        auto_bypass_modes=[],
+        allow_open=False,
+        trigger_unavailable=False,
+        arm_on_close=False,
+        use_exit_delay=True,
+        use_entry_delay=True,
+    )
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=[area],
+        sensors=[sensor_config],
+        entry_id="test_unknown_to_closed",
+    )
+
+    # Mock the alarm entity's last state
+    mock_restore_cache(
+        hass,
+        [
+            State(ALARM_ENTITY, "armed_away", {"arm_mode": "armed_away"}),
+        ],
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        # Set sensor to unknown BEFORE integration starts
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "unknown")
+        await hass.async_block_till_done()
+
+        # Setup the integration
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        await advance_time(hass, 1)
+
+        # Alarm should be armed (sensor was unknown)
+        assert_alarm_state(hass, ALARM_ENTITY, "armed_away")
+
+        # Change sensor from unknown to closed (safe state)
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "off")
+        await hass.async_block_till_done()
+        await advance_time(hass, 1)
+
+        # Alarm should still be armed (unknown -> closed treated as initial state)
+        assert_alarm_state(hass, ALARM_ENTITY, "armed_away")
+
+        # Cleanup
+        await hass.services.async_call(
+            "alarmo",
+            "disarm",
+            {
+                "entity_id": ALARM_ENTITY,
+                "code": "1234",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert_alarm_state(hass, ALARM_ENTITY, "disarmed")
+        await cleanup_timers(hass)
+
+
+@pytest.mark.asyncio
+async def test_sensor_unknown_to_open_with_allow_open_does_not_trigger(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Test that unknown to open does not trigger when allow_open is set.
+
+    Scenario: User arms with a window open (allow_open=True), restarts HA.
+    Sensor was unknown on restart, then recovers to open.
+    Expected: Alarm stays armed (allow_open is respected for unknown->open).
+    """
+    area = AreaFactory.create_area(
+        area_id="area_1",
+        name="Test Area 1",
+        armed_away_entry_time=10,
+    )
+    sensor_config = SensorFactory.create_door_sensor(
+        entity_id=GENERIC_DOOR_SENSOR,
+        name="Generic Area 1 Door",
+        area="area_1",
+        modes=["armed_away", "armed_home"],
+        always_on=False,
+        auto_bypass=False,
+        auto_bypass_modes=[],
+        allow_open=True,
+        trigger_unavailable=False,
+        arm_on_close=False,
+        use_exit_delay=True,
+        use_entry_delay=True,
+    )
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=[area],
+        sensors=[sensor_config],
+        entry_id="test_unknown_to_open_allow_open",
+    )
+
+    # Mock the alarm entity's last state
+    mock_restore_cache(
+        hass,
+        [
+            State(ALARM_ENTITY, "armed_away", {"arm_mode": "armed_away"}),
+        ],
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        # Set sensor to unknown BEFORE integration starts
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "unknown")
+        await hass.async_block_till_done()
+
+        # Setup the integration
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        await advance_time(hass, 1)
+
+        # Alarm should be armed (sensor was unknown)
+        assert_alarm_state(hass, ALARM_ENTITY, "armed_away")
+
+        # Change sensor from unknown to open
+        #   allow_open=True means this should be treated as initial state
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "on")
+        await hass.async_block_till_done()
+        await advance_time(hass, 1)
+
+        # Alarm should still be armed (allow_open respected)
+        assert_alarm_state(hass, ALARM_ENTITY, "armed_away")
+
+        # Cleanup
+        await hass.services.async_call(
+            "alarmo",
+            "disarm",
+            {
+                "entity_id": ALARM_ENTITY,
+                "code": "1234",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert_alarm_state(hass, ALARM_ENTITY, "disarmed")
+        await cleanup_timers(hass)
+
+
+@pytest.mark.asyncio
+async def test_sensor_normal_open_after_unknown_still_triggers(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Test that a normal open after unknown->closed still triggers alarm.
+
+    Scenario: Sensor recovers from unknown to closed (ignored), then opens.
+    Expected: Alarm should trigger on the second transition (regression check).
+    """
+    area = AreaFactory.create_area(
+        area_id="area_1",
+        name="Test Area 1",
+        armed_away_entry_time=10,
+    )
+    sensor_config = SensorFactory.create_door_sensor(
+        entity_id=GENERIC_DOOR_SENSOR,
+        name="Generic Area 1 Door",
+        area="area_1",
+        modes=["armed_away", "armed_home"],
+        always_on=False,
+        auto_bypass=False,
+        auto_bypass_modes=[],
+        allow_open=False,
+        trigger_unavailable=False,
+        arm_on_close=False,
+        use_exit_delay=True,
+        use_entry_delay=True,
+    )
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=[area],
+        sensors=[sensor_config],
+        entry_id="test_unknown_then_normal_open",
+    )
+
+    # Mock the alarm entity's last state
+    mock_restore_cache(
+        hass,
+        [
+            State(ALARM_ENTITY, "armed_away", {"arm_mode": "armed_away"}),
+        ],
+    )
+
+    with patch_alarmo_integration_dependencies(storage):
+        # Set sensor to unknown BEFORE integration starts
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "unknown")
+        await hass.async_block_till_done()
+
+        # Setup the integration
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        await advance_time(hass, 1)
+
+        # Alarm should be armed (sensor was unknown)
+        assert_alarm_state(hass, ALARM_ENTITY, "armed_away")
+
+        # Step 1: Unknown -> closed (treated as initial state, no trigger)
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "off")
+        await hass.async_block_till_done()
+        await advance_time(hass, 1)
+
+        assert_alarm_state(hass, ALARM_ENTITY, "armed_away")
+
+        # Step 2: Closed -> open (normal trigger)
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "on")
+        await hass.async_block_till_done()
+        await advance_time(hass, 1)
+
+        # Alarm should be in pending (entry delay)
+        assert_alarm_state(hass, ALARM_ENTITY, "pending")
+
+        # Advance past entry delay to trigger
+        await advance_time(hass, area["modes"]["armed_away"]["entry_time"] + 1)
+        assert_alarm_state(hass, ALARM_ENTITY, "triggered")
+
+        # Cleanup
+        await hass.services.async_call(
+            "alarmo",
+            "disarm",
+            {
+                "entity_id": ALARM_ENTITY,
+                "code": "1234",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert_alarm_state(hass, ALARM_ENTITY, "disarmed")
+        await cleanup_timers(hass)


### PR DESCRIPTION
## Description

When a door contact sensor transitions UNKNOWN→OPEN→CLOSED (e.g., after temporary disconnection or restart), Alarmo treated the UNKNOWN→OPEN transition as "initial state" and ignored it. If the sensor then closes quickly, the open event is permanently lost.

## Fix

In `async_sensor_state_changed()` (`sensors.py`), replaced the blanket early-return on `old_state == STATE_UNKNOWN` with a state-aware check. Transitions from UNKNOWN to safe states (CLOSED/OFF) are still treated as initial. Transitions from UNKNOWN to violation states (OPEN) now proceed through normal trigger evaluation.

## Related Issue

Fixes #1450