### PR TITLE
fix: prevent duplicate notification execution with master entity

### DIFF
--- a/custom_components/alarmo/alarm_control_panel.py
+++ b/custom_components/alarmo/alarm_control_panel.py
@@ -323,9 +323,10 @@ class AlarmoBaseEntity(AlarmControlPanelEntity, RestoreEntity):
     async def _validate_code(self, code, to_state):  # noqa PLR0911
         """Validate code and user permissions for a requested state change.
 
-        Returns a (success, info) tuple. 
+        Returns a (success, info) tuple.
         When validation is successful, success is True, otherwise False.
-        When success is True, info is the user data (or None if no user/code was needed).
+        When success is True, info is the user data
+            (or None if no user/code was needed).
         When success is False, info is the error event.
         """
         # check bypass rules

--- a/custom_components/alarmo/automations.py
+++ b/custom_components/alarmo/automations.py
@@ -44,6 +44,8 @@ def validate_area(trigger, area_id, hass):
         return False
     elif trigger[const.ATTR_AREA]:
         return trigger[const.ATTR_AREA] == area_id
+    elif area_id and hass.data[const.DOMAIN].get("master"):
+        return False
     elif len(hass.data[const.DOMAIN]["areas"]) == 1:
         return True
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ line-ending = "auto"
 ignore = [
     "D105",    #missing-docstring-in-init
     "PLR2004", #Magic Values
+    "PLR0917", #too-many-positional-arguments
     "D203",    #no-blank-line-before-class
     "D212",    #multi-line-summary-first-line
 ]

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 from homeassistant.const import ATTR_SERVICE, CONF_SERVICE_DATA
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from pytest_homeassistant_custom_component.common import async_mock_service
 
 from custom_components.alarmo import const
@@ -233,3 +234,138 @@ async def test_process_service_data_handles_lists_and_depth(
     assert shallow["message"] == "hello"
     assert shallow["nested"]["inner"] == "world"
     assert shallow["items"][0] == "one"
+
+
+@pytest.mark.asyncio
+async def test_notification_fires_once_per_event_with_master(
+    hass: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Area dispatches skipped when master + global trigger exists."""
+    master_entity = SimpleNamespace(
+        entity_id="alarm_control_panel.master", _arm_mode="armed_away"
+    )
+    area_1_entity = SimpleNamespace(
+        entity_id="alarm_control_panel.area_1", _arm_mode="armed_away"
+    )
+
+    automations = {
+        "notify_1": {
+            "automation_id": "notify_1",
+            const.ATTR_TYPE: const.ATTR_NOTIFICATION,
+            "name": "Global Notification",
+            const.ATTR_TRIGGERS: [
+                {
+                    const.ATTR_AREA: None,
+                    const.ATTR_EVENT: "armed",
+                    const.ATTR_MODES: ["armed_away"],
+                }
+            ],
+            const.ATTR_ACTIONS: [],
+            const.ATTR_ENABLED: True,
+        }
+    }
+
+    store = _DummyStore(automations=automations)
+    hass.data[const.DOMAIN] = {
+        "coordinator": _DummyCoordinator(store),
+        "areas": {"area_1": area_1_entity},
+        "master": master_entity,
+    }
+
+    handler = AutomationHandler(hass)
+
+    calls: list[tuple[str, Any]] = []
+
+    async def _mock_execute(auto_id: str, entity: Any) -> None:
+        calls.append((auto_id, entity))
+
+    monkeypatch.setattr(handler, "async_execute_automation", _mock_execute)
+
+    async_dispatcher_send(
+        hass, "alarmo_state_updated", "area_1", "disarmed", "armed_away"
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 0, f"Expected 0 for area dispatch, got {len(calls)}"
+
+    async_dispatcher_send(
+        hass, "alarmo_state_updated", None, "disarmed", "armed_away"
+    )
+    await hass.async_block_till_done()
+    assert len(calls) == 1, f"Expected 1 for master dispatch, got {len(calls)}"
+    assert calls[0][0] == "notify_1"
+    assert calls[0][1] is master_entity
+
+
+@pytest.mark.asyncio
+async def test_notification_fires_per_area_without_master(
+    hass: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without a master entity, area-level dispatches execute normally per area."""
+    area_1_entity = SimpleNamespace(
+        entity_id="alarm_control_panel.area_1", _arm_mode="armed_away"
+    )
+    area_2_entity = SimpleNamespace(
+        entity_id="alarm_control_panel.area_2", _arm_mode="armed_away"
+    )
+
+    automations = {
+        "notify_1": {
+            "automation_id": "notify_1",
+            const.ATTR_TYPE: const.ATTR_NOTIFICATION,
+            "name": "Area 1 Notification",
+            const.ATTR_TRIGGERS: [
+                {
+                    const.ATTR_AREA: "area_1",
+                    const.ATTR_EVENT: "armed",
+                    const.ATTR_MODES: ["armed_away"],
+                }
+            ],
+            const.ATTR_ACTIONS: [],
+            const.ATTR_ENABLED: True,
+        },
+        "notify_2": {
+            "automation_id": "notify_2",
+            const.ATTR_TYPE: const.ATTR_NOTIFICATION,
+            "name": "Area 2 Notification",
+            const.ATTR_TRIGGERS: [
+                {
+                    const.ATTR_AREA: "area_2",
+                    const.ATTR_EVENT: "armed",
+                    const.ATTR_MODES: ["armed_away"],
+                }
+            ],
+            const.ATTR_ACTIONS: [],
+            const.ATTR_ENABLED: True,
+        },
+    }
+
+    store = _DummyStore(automations=automations)
+    hass.data[const.DOMAIN] = {
+        "coordinator": _DummyCoordinator(store),
+        "areas": {"area_1": area_1_entity, "area_2": area_2_entity},
+        "master": None,
+    }
+
+    handler = AutomationHandler(hass)
+
+    calls: list[str] = []
+
+    async def _mock_execute(auto_id: str, entity: Any) -> None:
+        calls.append(auto_id)
+
+    monkeypatch.setattr(handler, "async_execute_automation", _mock_execute)
+
+    async_dispatcher_send(
+        hass, "alarmo_state_updated", "area_1", "disarmed", "armed_away"
+    )
+    await hass.async_block_till_done()
+    assert "notify_1" in calls
+    assert "notify_2" not in calls
+
+    calls.clear()
+
+    async_dispatcher_send(
+        hass, "alarmo_state_updated", "area_2", "disarmed", "armed_away"
+    )
+    await hass.async_block_till_done()
+    assert "notify_2" in calls


### PR DESCRIPTION
## Description

When a notification action is configured for the master entity, it fires multiple times per event (once per area + once for master). The master entity propagates commands to all areas, and each area's state change triggers the notification separately.

## Fix

In `async_alarm_state_changed()` (`automations.py`), when processing an area-level state change, skip execution if a master exists and the automation also has a master/global trigger — the master dispatch will handle it.

## Related Issue

Fixes #1366