### PR TITLE
fix: keep sensor config as dict before HA startup completes

### DIFF
--- a/custom_components/alarmo/sensors.py
+++ b/custom_components/alarmo/sensors.py
@@ -130,7 +130,11 @@ class SensorHandler:
 
     def __init__(self, hass: HomeAssistant):
         """Initialize the sensor handler."""
-        self._config = None
+        # The sensor config is only loaded once HA has finished starting (see
+        # _setup_sensor_listeners below). Until then this must be an empty dict
+        # rather than None: restoring a persisted alarm state can call into
+        # active_sensors_for_alarm_state() before that point.
+        self._config = {}
         self.hass = hass
         self._state_listener = None
         self._subscriptions = []
@@ -144,9 +148,10 @@ class SensorHandler:
         @callback
         def async_update_sensor_config():
             """Sensor config updated, reload the configuration."""
-            self._config = self.hass.data[const.DOMAIN][
-                "coordinator"
-            ].store.async_get_sensors()
+            self._config = (
+                self.hass.data[const.DOMAIN]["coordinator"].store.async_get_sensors()
+                or {}
+            )
             self._groups = self.hass.data[const.DOMAIN][
                 "coordinator"
             ].store.async_get_sensor_groups()

--- a/tests/test_startup_sensor_config_race.py
+++ b/tests/test_startup_sensor_config_race.py
@@ -1,0 +1,93 @@
+"""Test that Alarmo sets up before the sensor config has been loaded.
+
+SensorHandler defers loading its sensor config until EVENT_HOMEASSISTANT_STARTED,
+but the alarm entities restore their persisted state during platform setup, which
+happens earlier in the startup sequence. Restoring the 'arming' state calls
+async_arm(), which reaches into SensorHandler before its config is available.
+
+Regression test for https://github.com/nielsfaber/alarmo/issues/1429
+"""
+
+from typing import Any
+
+import pytest
+from homeassistant.core import State, CoreState
+from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+from tests.helpers import (
+    cleanup_timers,
+    setup_alarmo_entry,
+    patch_alarmo_integration_dependencies,
+)
+from tests.factories import AreaFactory, SensorFactory
+
+ALARM_ENTITY = "alarm_control_panel.test_area_1"
+GENERIC_DOOR_SENSOR = "binary_sensor.generic_area_1_door_sensor"
+
+
+@pytest.mark.asyncio
+async def test_setup_restoring_arming_state_before_ha_started(
+    hass: Any, enable_custom_integrations: Any
+) -> None:
+    """Test setup succeeds when restoring 'arming' before HA has finished starting.
+
+    Scenario: HA is restarted during the exit delay, so the entity restores the
+    'arming' state during platform setup, while HA is still starting and the sensor
+    config has therefore not been loaded yet.
+    Expected: the entity is added successfully instead of raising during setup.
+
+    Note: only 'arming' reproduces this. Restoring 'pending'/'triggered' calls
+    async_trigger(), which reads the area config rather than the sensor config.
+    """
+    area = AreaFactory.create_area(area_id="area_1", name="Test Area 1")
+    sensor_config = SensorFactory.create_door_sensor(
+        entity_id=GENERIC_DOOR_SENSOR,
+        name="Generic Area 1 Door",
+        area="area_1",
+        modes=["armed_away", "armed_home"],
+        always_on=False,
+        auto_bypass=False,
+        auto_bypass_modes=[],
+        allow_open=False,
+        trigger_unavailable=False,
+        arm_on_close=False,
+        use_exit_delay=True,
+        use_entry_delay=True,
+    )
+    storage, entry = setup_alarmo_entry(
+        hass,
+        areas=[area],
+        sensors=[sensor_config],
+        entry_id="test_startup_sensor_config_race",
+    )
+
+    mock_restore_cache(
+        hass,
+        [State(ALARM_ENTITY, "arming", {"arm_mode": "armed_away"})],
+    )
+
+    # HA has not finished starting, so SensorHandler has not loaded its config yet.
+    hass.set_state(CoreState.not_running)
+
+    with patch_alarmo_integration_dependencies(storage):
+        hass.states.async_set(GENERIC_DOOR_SENSOR, "off")
+        await hass.async_block_till_done()
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Previously the entity raised AttributeError while being added, so it never
+        # made it into the state machine and the integration provided no entity.
+        state = hass.states.get(ALARM_ENTITY)
+        assert state is not None, (
+            f"{ALARM_ENTITY} was not added when restoring 'arming' before "
+            "Home Assistant finished starting"
+        )
+        assert state.state != "unavailable"
+
+        # Completing startup loads the sensor config and evaluates the restored state.
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+        assert hass.states.get(ALARM_ENTITY) is not None
+        await cleanup_timers(hass)


### PR DESCRIPTION
## Description

On a cold boot, Alarmo can fail to create its alarm entity entirely. The panel then shows *"This entity is no longer being provided by the alarmo integration"*, and the alarm is silently gone until the config entry is reloaded.

```
Error adding entity alarm_control_panel.alarmo for domain alarm_control_panel with platform alarmo
Traceback (most recent call last):
  ...
  File "/config/custom_components/alarmo/alarm_control_panel.py", line 819, in async_added_to_hass
    self.async_arm(self.arm_mode)
  File "/config/custom_components/alarmo/alarm_control_panel.py", line 972, in async_arm
    ].validate_arming_event(
  File "/config/custom_components/alarmo/sensors.py", line 303, in validate_arming_event
    sensors_list = self.active_sensors_for_alarm_state(area_id, target_state)
  File "/config/custom_components/alarmo/sensors.py", line 275, in active_sensors_for_alarm_state
    for entity, config in self._config.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

## Root cause

`SensorHandler.__init__` defers `_setup_sensor_listeners()` — and therefore the first `_async_update_sensor_config()` that populates `self._config` — until `EVENT_HOMEASSISTANT_STARTED`:

```python
if hass.state == CoreState.running:
    ...
else:
    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, handle_startup)
```

But `AlarmoBaseEntity.async_added_to_hass()` restores the persisted state during *platform setup*, which happens earlier in the startup sequence. If the restored state is `arming`, it calls `async_arm()`, which reaches `validate_arming_event()` → `active_sensors_for_alarm_state()` and iterates `self._config` while it is still `None`.

In practice this means: restart HA during the exit delay, and the alarm entity is gone on the way back up.

This only reproduces on a cold boot (`hass.state != CoreState.running`), which is why reloading the config entry works around it — on reload the config is already in memory.

Note the restored `pending` / `triggered` states do **not** hit this: they call `async_trigger()`, which reads the area config rather than the sensor config.

## Fix

Initialize `_config` to `{}` and coerce a `None` from `store.async_get_sensors()` to `{}`.

"No sensors known yet" is the correct semantics at this point rather than a workaround: `_setup_sensor_listeners()` already re-evaluates every armed area through `_async_evaluate_armed_state_on_startup()` once HA has started, so the authoritative sensor evaluation still happens — just a moment later, as designed.

## Tests

Added `tests/test_startup_sensor_config_race.py`, which sets `CoreState.not_running` before setup to reproduce the real startup ordering, restores `arming`, and asserts the entity is added. Verified both ways against this branch:

- with `self._config = None` restored → fails with the exact `AttributeError` above
- with the fix → passes

Full suite: 104 passed. `ruff check` and `ruff format` clean.

Deliberately placed in a new file rather than appended to `tests/test_startup_sensor_evaluation.py` so that it does not conflict with #1454, which appends to that file. The two changes are orthogonal — #1454 fixes `async_sensor_state_changed()` for `UNKNOWN → OPEN` transitions at runtime.

## Related issues

Fixes #1429. The same traceback also appears in #1358, #1370 and #1375, all closed without a fix having landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)