### PR TITLE
Allow 'Delay on' up to 5 minutes

### DIFF
--- a/custom_components/alarmo/frontend/dist/alarm-panel.js
+++ b/custom_components/alarmo/frontend/dist/alarm-panel.js
@@ -2092,7 +2092,7 @@ const qs=2;class Ps{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,a,i)
 
                   <alarmo-duration-picker
                     .hass=${this.hass}
-                    max="60"
+                    max="300"
                     step="5"
                     placeholder="-"
                     ?disabled=${!ms(this.data.delay_on)}

--- a/custom_components/alarmo/frontend/src/views/sensors/sensor-editor-card.ts
+++ b/custom_components/alarmo/frontend/src/views/sensors/sensor-editor-card.ts
@@ -350,7 +350,7 @@ export class SensorEditorCard extends SubscribeMixin(LitElement) {
 
                   <alarmo-duration-picker
                     .hass=${this.hass}
-                    max="60"
+                    max="300"
                     step="5"
                     placeholder="-"
                     ?disabled=${!isDefined(this.data.delay_on)}


### PR DESCRIPTION
Fixes #1434

Raises the per-sensor **Delay on** picker maximum from 60 s to 300 s (5 minutes), as agreed with the maintainer in the issue.

- Frontend-only change (`sensor-editor-card.ts`): `max="60"` → `max="300"`, step 5.
- Rebuilt bundle committed.
- No backend/storage change — the backend already accepts any positive integer for `delay_on`.

Supports the use cases from the request (camera loitering detection, garage gates) while keeping a security-reasonable cap.